### PR TITLE
Smooth obs and actions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,54 @@
+# MycorMARL Domain Context
+
+## Glossary
+
+### Operational agent
+
+An agent that is configured as present, biologically alive, and able to
+participate in the environment process at the specified transition boundary.
+`operational_at_start` and `operational_at_end` record this status before and
+after one environment step.
+
+An absent single-consumer counterpart and an already dead organism are both
+non-operational. A change from operational to non-operational during a
+transition is a biological termination event.
+
+### Physical action
+
+The bounded resource-allocation command passed to `BaseMycorMarl`:
+`[trade, growth, reproduction, reserve]`, where trade is independently bounded
+and the remaining three components form a simplex.
+
+A physical action is valid by construction before it reaches the environment.
+`BaseMycorMarl` executes it unchanged and does not clip, sanitise, project, or
+renormalise it. PPO produces physical actions through its latent transforms;
+non-policy callers use the shared public action-construction helper.
+
+### Transition
+
+A stable, typed JAX PyTree produced by `BaseMycorMarl` for one agent during a
+completed environment step. A `Transition` contains algorithm-independent
+facts, including realised biological actions, whether an action component
+executed, biological termination, administrative truncation, and the agent's
+final pre-reset observation.
+
+A `Transition` describes what happened in the model. It is not a PPO
+trajectory sample and does not contain PPO loss masks, GAE controls,
+advantages, value targets, or other learning-algorithm bookkeeping. Loose
+human-facing diagnostics remain separate from this stable contract.
+
+Every step returns a fixed mapping with one `Transition` for `plant` and one
+for `fungus`, including in single-consumer modes and after death. The
+administrative truncation flag is identical in both instances.
+
+Lifecycle is represented by `operational_at_start` and
+`operational_at_end`, not only by a sticky termination flag. This preserves
+the distinction between an organism that dies during the current transition
+and one that was already dead or absent.
+
+### PPO transition adapter
+
+A small pure function in the PPO layer that converts a `Transition` into the
+trajectory fields needed by independent PPO. It derives PPO validity masks and
+bootstrap/trace controls without making `BaseMycorMarl` depend on PPO. It is
+not a class, framework, or extensibility layer.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,3 +52,15 @@ A small pure function in the PPO layer that converts a `Transition` into the
 trajectory fields needed by independent PPO. It derives PPO validity masks and
 bootstrap/trace controls without making `BaseMycorMarl` depend on PPO. It is
 not a class, framework, or extensibility layer.
+
+### Biomass-derived uptake geometry
+
+The root and external-hyphal length-density fields reconstructed from an
+organism's current biomass before soil uptake. These fields represent current
+living uptake infrastructure, not a persistent record of previously occupied
+soil.
+
+Maintenance-induced biomass loss therefore changes uptake geometry through the
+same biomass-to-geometry conversion as any other biomass change. The model does
+not retain thinning, damage, abandoned territory, or a historical growth front
+once biomass is restored.

--- a/docs/adr/0001-keep-environment-independent-of-ppo.md
+++ b/docs/adr/0001-keep-environment-independent-of-ppo.md
@@ -1,0 +1,40 @@
+# ADR-0001: Keep `BaseMycorMarl` independent of PPO
+
+**Status:** Accepted
+
+## Context
+
+`BaseMycorMarl` is a biological multi-agent environment. Independent PPO needs
+additional trajectory bookkeeping, including actor-valid, trade-active, and
+critic-valid masks plus termination/truncation bootstrap controls.
+
+Returning those PPO concepts directly from the environment would couple the
+scientific model to one learning algorithm and make the transition semantics
+harder to reuse or test independently.
+
+## Decision
+
+`BaseMycorMarl` will emit only an algorithm-independent `Transition` through
+its standard JaxMARL boundary. Its facts include:
+
+- requested and realised biological action components;
+- whether allocation and trade actually executed;
+- biological termination and administrative truncation;
+- the final pre-reset observation needed at an auto-reset boundary.
+
+A small pure PPO transition-adapter function in the algorithm layer will
+convert the `Transition` into the trajectory schema used by independent PPO.
+It will derive actor, trade, critic, bootstrap, and GAE trace masks without
+introducing an adapter class or framework.
+
+The environment must not import PPO modules or expose fields named in terms of
+PPO losses, advantages, value targets, GAE, or policy optimisation.
+
+## Consequences
+
+- Environment dynamics and accounting can be tested without constructing PPO.
+- PPO boundary semantics have one explicit, independently testable conversion
+  point.
+- Other algorithms can consume the same `Transition`.
+- The adapter becomes a required integration component and must have contract
+  tests against representative environment transitions.

--- a/docs/adr/0002-use-a-typed-transition-contract.md
+++ b/docs/adr/0002-use-a-typed-transition-contract.md
@@ -1,0 +1,69 @@
+# ADR-0002: Use a typed `Transition` contract
+
+**Status:** Accepted
+
+## Context
+
+The small PPO transition-adapter function needs execution, termination, truncation, and
+pre-reset observation facts from `BaseMycorMarl`. If these essential facts are
+mixed into an informal diagnostic dictionary, spelling or shape drift can
+silently change learning semantics.
+
+The repository currently has a PPO `Trajectory` type but no type named
+`Transition`.
+
+## Decision
+
+`BaseMycorMarl` will expose essential step facts through a stable, typed JAX
+PyTree named `Transition`. `Transition` is a per-agent type. Every environment
+step returns a fixed mapping:
+
+```text
+{
+    "plant": Transition(...),
+    "fungus": Transition(...),
+}
+```
+
+The fixed mapping is preserved in mixed, plant-only, fungus-only, living, and
+dead-agent states.
+
+`Transition` is algorithm-independent. It describes what happened during one
+environment step and does not contain PPO masks, advantages, value targets,
+GAE controls, or optimiser state.
+
+Loose diagnostics are not fields in the stable `Transition` contract. They
+remain a separate output intended for inspection rather than learning
+correctness.
+
+Administrative truncation is a joint boundary fact but is copied into both
+per-agent instances so each independent-policy adapter input is self-contained.
+The two values must be identical and this is an environment invariant.
+
+Each per-agent `Transition` includes at least:
+
+- `operational_at_start`;
+- `operational_at_end`;
+- `allocation_executed`;
+- `trade_executed`;
+- `truncated`;
+- `final_observation`.
+
+Lifecycle uses start and end operational status rather than a single sticky
+termination flag. The PPO transition-adapter function derives biological termination
+from an operational-to-non-operational change and excludes already dead or
+absent transitions using `operational_at_start`.
+
+## Consequences
+
+- JIT, scan, and vmap see a fixed transition structure and fixed field shapes.
+- The PPO transition-adapter function depends on typed fields rather than stringly typed
+  diagnostic keys.
+- Plant and fungal PPO processing can consume the same per-agent schema
+  independently.
+- Joint truncation is duplicated deliberately and requires an equality test.
+- Death transitions and already-dead padding remain distinguishable without
+  adding PPO validity masks to the environment.
+- Schema changes become explicit compatibility changes with focused tests.
+- `Transition` and PPO `Trajectory` have distinct meanings documented in the
+  project glossary.

--- a/docs/adr/0003-require-valid-physical-actions-at-the-environment-boundary.md
+++ b/docs/adr/0003-require-valid-physical-actions-at-the-environment-boundary.md
@@ -1,0 +1,41 @@
+# ADR-0003: Require valid physical actions at the environment boundary
+
+**Status:** Accepted
+
+## Context
+
+PPO computes a likelihood for the action generated from its latent sample. If
+`BaseMycorMarl` clips, sanitises, projects, or renormalises that action, the
+executed action may differ from the action scored by PPO. Silent repair would
+therefore hide interface defects and corrupt the policy-gradient ratio.
+
+JAX runtime value checks inside the compiled environment loop would also add
+complexity to a path whose normal callers can satisfy the constraints by
+construction.
+
+## Decision
+
+Every caller must provide a valid physical action before invoking
+`BaseMycorMarl`.
+
+- PPO uses the agreed sigmoid and centred-simplex transforms.
+- Heuristics, tests, examples, and qualification scripts use one shared public
+  action-construction helper.
+- `BaseMycorMarl` consumes the physical action unchanged.
+- The compiled environment does not clip, replace non-finite values, project
+  to the simplex, renormalise, or provide a fallback allocation.
+- Optional validation may be provided as an explicit debug/test helper outside
+  the compiled training path. Invalid input is a contract violation, not a
+  recoverable environment event.
+
+Because the environment never repairs an action, `Transition` does not need an
+`action_was_projected` field.
+
+## Consequences
+
+- The PPO likelihood always describes the action the environment executes.
+- Invalid-action bugs fail focused contract tests instead of being hidden.
+- All repository action call sites must migrate to the shared constructor.
+- Direct external callers are responsible for satisfying the documented
+  bounds and simplex invariant.
+

--- a/docs/adr/0004-derive-uptake-geometry-from-current-biomass.md
+++ b/docs/adr/0004-derive-uptake-geometry-from-current-biomass.md
@@ -1,0 +1,64 @@
+# ADR-0004: Derive uptake geometry from current biomass
+
+**Status:** Accepted
+
+## Context
+
+Maintenance deficits can destroy plant or fungal biomass. Root and
+external-hyphal length-density fields determine the organisms' soil phosphate
+uptake geometry.
+
+One possible model would preserve the historical growth envelope and thin its
+density after biomass loss. That would make damage path-dependent, but it would
+also permit extremely sparse legacy networks and would require new rules for
+connected roots, fungal attachment, tissue abandonment, and whether subsequent
+growth repairs or extends the network.
+
+The current model instead reconstructs both density fields from post-allocation
+biomass before soil uptake.
+
+## Decision
+
+Root and external-hyphal uptake geometry will remain a memoryless function of
+current living biomass and static traits.
+
+- Maintenance-induced biomass loss has no separate persistent damage state.
+- Fungal loss retracts the saturated hemispherical colony boundary.
+- Plant loss reduces the radial extent of the root disc in each represented
+  depth layer; the configured rooting-depth distribution remains unchanged.
+- Later regrowth may recreate previously occupied geometry.
+- The model will not currently track a historical front, local density damage,
+  a minimum-density backbone, or explicit root–fungus connectivity.
+
+Density fields continue to be reconstructed after maintenance and allocation,
+so maintenance loss cannot be offset by growth within the same transition:
+any maintenance deficit exhausts at least one essential resource required for
+growth.
+
+## Consequences
+
+- Uptake geometry remains connected by construction under its axisymmetric
+  geometric assumptions and cannot become a near-zero-density legacy network.
+- Equal current biomass and traits imply equal uptake geometry, regardless of
+  maintenance history.
+- Policies may rebuild retracted uptake territory in later transitions by
+  allocating resources to growth.
+- The biological model does not represent persistent tissue damage or enforce
+  fungal attachment to living roots.
+- Introducing path-dependent density loss later would reopen this decision and
+  require explicit spatial-connectivity and regrowth semantics.
+
+## Potential extension
+
+Maintenance-deficit mortality could later reduce length density within the
+established root or mycelial envelope instead of retracting the uptake
+geometry. This extension should not be introduced as proportional density
+scaling alone: repeated deficits could otherwise leave an arbitrarily sparse
+network that remains spatially extensive but is no longer biologically capable
+of supporting resource transport.
+
+A complementary extension would therefore model network transport capacity and
+use it to define the minimum viable connected density. Density loss, survival,
+front extension, and any removal of disconnected tissue would then be governed
+by whether the remaining root or mycelial network can transport sufficient
+resources between its uptake surfaces and the plant–fungus exchange region.

--- a/docs/growth-model.md
+++ b/docs/growth-model.md
@@ -157,6 +157,12 @@ $$
 R_f=\left(\frac{3L_h}{2\pi\lambda_{sat}}\right)^{1/3}.
 $$
 
+The inverse transformations from colony radius to saturated length and from
+length to dry biomass are owned by the same mycelium module. Their composition,
+[`fungal_biomass_for_colony_radius`](../mycormarl/mycormarl/fungus/mycelium.py),
+provides the radial-fill biomass. Half of that value is used as the fungal
+actor-observation reference.
+
 Each annular cell receives $\lambda_{sat}$ times its exact occupied-volume
 fraction. Implemented by
 [`colony_radius_from_length_axisymmetric`](../mycormarl/mycormarl/fungus/mycelium.py#L28-L30),

--- a/docs/growth-model.md
+++ b/docs/growth-model.md
@@ -8,12 +8,14 @@
 
 ## Executive summary
 
-Plant and fungus allocate fractions of their start-of-step free C and P pools
-to trade, growth, maintenance, and reproduction. Growth treats C and P as
-essential resources: the scarcer resource after conversion by organism-specific
-stoichiometric costs limits new dry biomass. Maintenance shortfalls remove
-biomass, reproduction exports resources and generates reward, and death does not
-replenish C or P resources.
+Plant and fungus pay unavoidable maintenance from their start-of-step free C
+and P pools, then execute a Physical action
+`[trade, growth, reproduction, reserve]`. Trade is independently bounded;
+growth, reproduction, and reserve form a simplex applied separately to
+remaining C and P. Growth treats C and P as essential resources: the scarcer
+resource after conversion by organism-specific stoichiometric costs limits new
+dry biomass. Maintenance shortfalls remove biomass, reproduction exports
+resources and generates reward, and death does not replenish C or P resources.
 
 Surviving plant biomass is mapped to a stack of depth-dependent root discs with
 uniform within-disc length density. Surviving fungal biomass is mapped to an
@@ -62,8 +64,8 @@ P_{o,m}^{*}=G_o\kappa_{P,o}\Delta t,
 $$
 
 with $\kappa_C$ in g C g⁻¹ day⁻¹, $\kappa_P$ in mg P g⁻¹ day⁻¹, and
-$\Delta t$ in days. Actual use is the lesser of allocated and required
-resource. A deficit is translated to lost biomass using the more severe
+$\Delta t$ in days. Actual use is the lesser of the start-of-step free pool and
+required resource. A deficit is translated to lost biomass using the more severe
 stoichiometric deficit:
 
 $$
@@ -72,12 +74,10 @@ $$
           \frac{P_{o,m}^{*}-P_{o,m}}{\gamma_{P,o}},0\right).
 $$
 
-The current implementation is visible for the plant at
-[`base_mycor.py:508–546`](../mycormarl/mycormarl/environments/base_mycor.py#L508-L546)
-and fungus at
-[`base_mycor.py:606–644`](../mycormarl/mycormarl/environments/base_mycor.py#L606-L644).
-Over-allocation is returned to the pools, as tested by
-[`test_excess_maintenance_allocation_is_not_wasted`](../tests/test_base_mycor_refactor.py#L288-L315).
+The shared automatic payment transaction is implemented in
+[`BaseMycorMarl._pay_maintenance`](../mycormarl/mycormarl/environments/base_mycor.py).
+Reserved resources remain untouched after maintenance, as tested by
+[`test_automatic_maintenance_does_not_spend_reserved_resources`](../tests/test_base_mycor_refactor.py).
 
 Reproduction removes allocated C and P and scores a Cobb–Douglas reward after
 both resources are converted to dry-biomass equivalents. Plant C trade and
@@ -87,9 +87,9 @@ trade is unavailable for same-step growth. See
 [`test_incoming_trade_is_not_available_for_same_step_growth`](../tests/test_base_mycor_refactor.py#L209-L221).
 
 Structural P associated with biomass lost to maintenance shortfall is added to
-cumulative mortality-loss diagnostics. It is not recycled to soil. Free P used
-for maintenance is deducted but currently has no destination; this is an
-acknowledged accounting gap rather than a C-only maintenance assumption.
+cumulative mortality-loss diagnostics. It is not recycled to soil. Free P
+actually paid for maintenance is recorded separately in plant and fungal
+maintenance-loss counters; unmet demand is recorded only as a deficit.
 
 ## Plant biomass to root geometry
 

--- a/docs/ippo-actor-interface-implementation-plan.md
+++ b/docs/ippo-actor-interface-implementation-plan.md
@@ -1,0 +1,962 @@
+# Biologically Plausible IPPO Actor Interface Implementation Plan
+
+**Status:** Reviewed proposal; implementation has not started.
+
+## Summary
+
+Replace the current four-way maintenance/trade/growth/reproduction allocation
+and unconstrained Gaussian PPO policy with a compact, biologically plausible
+independent-PPO walking skeleton for the plant and fungal actors.
+
+Each actor will observe five bounded local signals: its own biomass, carbon
+reserve, phosphorus reserve, most recently received partner resource, and
+current partner association. Each actor will produce one independent trade
+fraction plus a growth/reproduction/reserve simplex. Maintenance will become
+an unavoidable automatic C/P debit paid before learned allocation. PPO will
+sample three latent Gaussian coordinates through two actor output heads and
+transform them into the four physical actions without clipping or
+renormalising the sampled Gaussian action.
+
+The implementation will preserve intentionally partial observability,
+independent local critics, the existing `0.025 day` environment/action
+timestep, deterministic maintenance-deficit mortality, and Cobb-Douglas
+reproductive fitness. It will distinguish biological termination from an
+administrative episode truncation so that death does not bootstrap while the
+arbitrary maximum-step boundary does.
+
+This plan includes explanations for the key decisions because the interface is
+part scientific model and part learning system: several alternatives are
+technically possible but imply different biological objectives.
+
+`CONTEXT.md` is not present. This plan therefore takes the repository code,
+tests, implementation documentation, and the MycorMARL working diary as its
+authoritative context.
+
+## Execution Route
+
+`undecided`
+
+The constrained route is optional. No execution route has been selected yet.
+
+## Goals
+
+- Provide a small continuous action space whose executed resource transaction
+  matches the action probability used by PPO.
+- Keep `BaseMycorMarl` algorithm-independent and translate its typed
+  per-agent `Transition` instances through one small pure PPO helper.
+- Remove learned maintenance allocation while preserving unavoidable
+  biomass-dependent C/P costs and deterministic mortality.
+- Prevent the trade fraction from reserving the non-traded currency.
+- Give plant and fungus bounded, biologically plausible local observations
+  without exposing partner internals or global soil state.
+- Keep the plant and fungal actor-critics independent and feed-forward as the
+  baseline.
+- Preserve resource accounting, delayed availability of incoming resources,
+  sticky death, and the ability of a surviving facultative partner to
+  continue after the other agent dies.
+- Make the arbitrary episode limit a true training truncation while keeping
+  biological death terminal.
+- Add executable correctness tests for every new contract and retain a finite
+  JIT-compiled PPO smoke run.
+- Keep physical-time discount sensitivity configurable while using
+  undiscounted cumulative reproductive fitness as the default objective.
+
+## Non-goals
+
+- Centralised critics, MAPPO, parameter sharing between species, or privileged
+  critic observations.
+- Recurrent actors, frame stacking, belief-state estimation, or removal of
+  intentional partial observability.
+- Separate actor-decision and numerical integration intervals, held daily
+  actions, or timestep-invariant action-rate conversion.
+- Stochastic/background mortality, accumulated stress, ageing, senescence, or
+  maintenance-sacrifice/terminal-investment strategies.
+- Partitioning maintenance P among explicit repair, recycling, turnover, and
+  soil-return pools.
+- Treating Cobb-Douglas reward as a conserved reproductive-biomass pool or
+  introducing explicit propagule size and composition.
+- Broad convergence tuning, reward/return scaling studies, cross-play,
+  heuristic-partner evaluation, exploitability analysis, or claims of global
+  policy optimality.
+- Transformed-action entropy regularisation, separate actor/critic optimisers,
+  policy-sample wrapper types, or a general adapter framework. The walking
+  skeleton uses initial Gaussian exploration, one optimiser per species, and
+  one small pure PPO conversion helper.
+- Running the deferred adversarial-policy, discount-timescale, spatial,
+  timestep, and large scientific validation matrices. This plan only exposes
+  the necessary configuration and covers walking-skeleton correctness.
+- Changing the qualified `0.025 day` environment/action timestep.
+- Turning the arbitrary maximum-step boundary into a genuine annual lifecycle
+  endpoint. A future annual-species model will require seasonal/phenological
+  state and explicit terminal life-history semantics.
+
+## Users
+
+- The model developer connecting `BaseMycorMarl` to the repository's PPO
+  implementation.
+- Researchers using the plant/fungus policies as a transparent independent-PPO
+  baseline before expanding action, observation, memory, or critic structure.
+- Future model-development work comparing richer MARL designs against a small,
+  explicitly documented walking skeleton.
+
+## Requirements
+
+### 1. Observation contract
+
+Each live agent receives a float32 vector with shape `(5,)` in this order:
+
+1. own biomass;
+2. own carbon reserve;
+3. own phosphorus reserve;
+4. most recently received partner resource;
+5. current partner association (`0.0` or `1.0`).
+
+Use the fixed numerical guard:
+
+```text
+OBS_EPS = 1e-8
+denom_safe = max(denom, OBS_EPS)
+```
+
+Use `max`, not unconditional epsilon addition, so ordinary ratios are not
+systematically biased. Clamp physical inputs non-negative, define `0/0` as
+zero, and clip each transformed observation to `[0, 1]`.
+
+#### Biomass
+
+Use the same saturating transform for both species:
+
+```text
+o_B = B / (B + s_B)
+```
+
+For the plant:
+
+```text
+s_B,plant = 0.5 * plant.biomass_cap
+```
+
+For the fungus, first calculate the biomass whose existing saturated
+hemisphere reaches the configured outer soil radius `R`:
+
+```text
+L_radial_fill = (2 / 3) * pi * fungus.saturation_density * R^3
+B_radial_fill = (
+    L_radial_fill
+    * fungus.hyphal_tissue_carbon_density
+    * pi
+    * fungus.hyphal_radius^2
+    / fungus.gamma_c
+)
+s_B,fungus = 0.5 * B_radial_fill
+```
+
+This is a radial-extent reference, not a fungal biomass cap and not a claim
+that the entire cylindrical domain is filled.
+
+#### Carbon and phosphorus reserves
+
+Express free pools relative to the resource required to construct an amount of
+biomass equal to current biomass:
+
+```text
+o_C = C / max(C + gamma_C * B, OBS_EPS)
+o_P = P / max(P + gamma_P * B, OBS_EPS)
+```
+
+#### Most recently received trade
+
+Scale the received resource against the recipient's next-step maintenance
+demand:
+
+```text
+plant_need_P = plant.kappa_p * plant_biomass * dt
+plant_trade_obs = plant_last_p_received / max(
+    plant_last_p_received + plant_need_P,
+    OBS_EPS,
+)
+
+fungus_need_C = fungus.kappa_c * fungus_biomass * dt
+fungus_trade_obs = fungus_last_c_received / max(
+    fungus_last_c_received + fungus_need_C,
+    OBS_EPS,
+)
+```
+
+#### Association and dead observations
+
+Association is one only while both configured consumers are present, alive,
+and functionally able to exchange resources. It is zero in either independent
+consumer mode and after either partner dies.
+
+Dead and absent agents emit an all-zero observation. The per-agent termination
+and PPO validity masks, rather than an additional operational observation,
+distinguish death from an extremely resource-poor live state.
+
+#### Why this observation design
+
+- Saturating ratios give fixed bounded inputs without a running normaliser
+  whose meaning drifts during training.
+- Species-specific biomass scales avoid incorrectly normalising indeterminate
+  fungal growth by the plant cap while retaining the same transform shape.
+- Reserve ratios represent actionable internal physiology rather than raw
+  pools whose scale changes with biomass.
+- Received trade is biologically observable and gives one step of interaction
+  feedback without exposing the partner's pools, actions, or intentions.
+- Association separates a partner choosing zero trade from there being no
+  functioning partner.
+- Feed-forward partial observability is intentional: the baseline should not
+  solve partner-state inference with recurrence before the resource interface
+  itself is verified.
+
+### 2. State additions and accounting
+
+Add float32 arrays with the existing single-agent shape for:
+
+- `plant_last_p_received`;
+- `fungus_last_c_received`;
+- `cumulative_plant_p_maintenance_loss_mg`;
+- `cumulative_fungus_p_maintenance_loss_mg`.
+
+Initialise all four fields to zero. Last-received fields are observation
+memory, not resource pools. Update them from realised incoming trade and zero
+them for absent or dead recipients. `_get_obs(state)` must reconstruct the
+complete observation without an out-of-band `last_trade` parameter.
+
+Accumulate all actually paid maintenance P in the corresponding maintenance
+loss counter. Do not count unmet demand as a physical P loss.
+
+#### Why store received trade
+
+The actor observes a property of the immediately preceding transition. If it
+is not carried in environment state, the same saved `State` cannot reconstruct
+the observation that PPO received, making checkpoint/resume, deterministic
+replay, wrappers, and debugging unreliable.
+
+#### Why use a maintenance-P loss counter
+
+Real maintenance P can be recycled, repaired into tissue, or lost through
+turnover. Modelling those pools is outside the walking skeleton. Treating paid
+maintenance P as an explicit external maintenance/turnover loss preserves the
+current cost while closing accounting instead of silently deleting P.
+
+### 3. Physical action contract
+
+Each environment action is a float32 vector with shape `(4,)`:
+
+```text
+[trade, growth, reproduction, reserve]
+```
+
+The constraints are:
+
+```text
+0 <= trade <= 1
+growth >= 0
+reproduction >= 0
+reserve >= 0
+growth + reproduction + reserve = 1
+```
+
+Trade is not on the biological allocation simplex. Plant trade spends only C;
+fungal trade spends only P. The shared growth/reproduction/reserve fractions
+are applied separately to each resource pool remaining after maintenance and
+outgoing trade.
+
+Growth remains essential-resource limited:
+
+```text
+growth = min(C_growth / gamma_C, P_growth / gamma_P)
+```
+
+Charge only the C and P actually used by realised growth; unused
+non-limiting-resource growth allocation remains in the pool. Reproduction
+consumes both allocated resource amounts and retains the existing
+Cobb-Douglas fitness reward. Reserve is the portion not offered to growth or
+reproduction during the current step.
+
+Every caller must generate a valid physical action before invoking the
+environment. PPO uses its sigmoid and centred-simplex transforms; heuristics,
+tests, examples, and qualification scripts use one shared public
+action-construction helper. `BaseMycorMarl` executes the supplied action
+unchanged and must not clip, sanitise, project, renormalise, or substitute a
+fallback allocation. An explicit validation helper may fail loudly in tests
+or debug workflows outside the compiled training path.
+
+#### Why this action design
+
+- A single four-way simplex incorrectly reserves the trade fraction of the
+  currency that species cannot trade.
+- Two resource-specific simplexes would require five latent degrees of freedom
+  and permit many mismatched growth requests before the basic interface is
+  established.
+- One trade coordinate plus a three-part biological simplex uses three latent
+  degrees of freedom while retaining reserve behavior and the intended
+  Cobb-Douglas response to C/P imbalance.
+- Reserve must be explicit after maintenance becomes automatic; otherwise the
+  actor would be forced to spend all disposable resources every step.
+
+### 4. Automatic maintenance and transition order
+
+Remove maintenance from `Actions` and from the learned simplex. For each
+operational organism, execute one step in this order:
+
+1. Compute start-of-step C/P maintenance demand from biomass and `dt`.
+2. Pay as much demand as the free pools permit.
+3. Record paid maintenance P in the new loss counter.
+4. Convert C/P shortfall through the existing deterministic
+   maintenance-deficit biomass-loss rule.
+5. Update sticky death and current association.
+6. Cancel all sending and receiving for an organism that died during
+   maintenance; the partner retains any proposed outgoing transfer.
+7. Calculate surviving partners' simultaneous outgoing trade from their
+   post-maintenance traded-resource pools.
+8. Deduct outgoing trade and apply the shared growth/reproduction/reserve
+   simplex separately to the remaining C and P pools.
+9. Apply realised growth, reproduction export, and plant biomass cap.
+10. Update active root and hyphal geometry from surviving biomass.
+11. Run photosynthesis and the soil P evolution/uptake transaction.
+12. Credit incoming trade and newly acquired resources after allocation.
+13. Store realised received trade, increment the step, and construct reward,
+    observation, termination, truncation, and information outputs.
+
+Incoming trade, photosynthate, and soil uptake cannot fund allocation in the
+same step. An organism that dies during maintenance executes no learned
+action in that transition.
+
+#### Why maintenance is automatic
+
+Maintenance is an unavoidable physiological cost rather than a discretionary
+investment in the baseline. Making the random initial policy explicitly fund
+maintenance creates a sharp early-death exploration problem. Automatic debit
+retains the life-history trade-off indirectly: reproduction, growth, trade,
+and reserve choices determine whether future pools can meet unavoidable
+maintenance.
+
+#### Why deterministic mortality remains
+
+Maintenance deficit already provides a dense causal path from resource
+allocation to biomass loss and eventual death. Adding uncalibrated stochastic
+mortality would increase return variance and change the scientific model.
+Background and accumulated-stress hazards remain future extensions.
+
+### 5. Dead-agent behavior
+
+Death is sticky. After death:
+
+- freeze remaining free C/P and retained biomass as inert corpse bookkeeping;
+- keep retained resources in whole-system accounting but make them unavailable
+  to every active process;
+- perform no maintenance, trade, growth, reproduction, photosynthesis,
+  geometry formation, or soil uptake;
+- emit zero reward, zero action effect, zero observation, zero received-trade
+  memory, and association zero;
+- keep the surviving partner active until its own death or a global reset.
+
+Do not add corpse decomposition, recycling, or soil return.
+
+#### Why retain inert corpse resources
+
+This prevents dead agents from affecting the environment without inventing a
+decomposition model. Frozen pools make the simplification visible in balance
+diagnostics instead of silently transferring resources to another compartment.
+
+### 6. PPO actor and critic contract
+
+Retain separate plant and fungal actor-critic parameter trees. Each critic sees
+only its own five-element actor observation.
+
+Within each actor, use one shared feed-forward encoder and two minimal output
+heads:
+
+- trade head: one Gaussian latent `z_trade`;
+- allocation head: two diagonal-Gaussian latents `z_allocation_1`,
+  `z_allocation_2`.
+
+Transform them as:
+
+```text
+trade = sigmoid(z_trade)
+allocation_logits = [
+    z_allocation_1 / sqrt(2) + z_allocation_2 / sqrt(6),
+   -z_allocation_1 / sqrt(2) + z_allocation_2 / sqrt(6),
+   -2 * z_allocation_2 / sqrt(6),
+]
+[growth, reproduction, reserve] = softmax(allocation_logits)
+```
+
+Initialise:
+
+- trade location bias to `logit(0.1)`, giving a 10% initial median;
+- both allocation location biases to zero and use equal initial allocation
+  scales, so the location-transformed action is exactly uniform and the
+  centred logistic-normal distribution is exchangeable across growth,
+  reproduction, and reserve, giving equal expected allocation;
+- exploration scale away from zero and away from a value that makes most
+  transformed samples saturate at the boundaries.
+
+Represent trade and allocation as factorised distributions even though they
+share a policy encoder. Keep separate latent log-probability and KL terms.
+Store both latent actions and executed physical actions in trajectories. The
+critic retains its own tower; the shared encoder is shared by the two policy
+heads, not between policy and value function.
+
+When association is absent at the decision state, force physical trade to zero
+and exclude the trade factor from PPO likelihood and KL. Continue to train
+allocation. If automatic maintenance kills an agent before its sampled action
+can execute, mask both actor factors for that transition but retain the
+pre-death critic target when the minibatch otherwise contains valid actor
+samples; the preceding action receives the future consequence through GAE.
+Bilateral trade cancellation also masks the surviving partner's trade factor
+for that transition, while its executed allocation factor remains trainable.
+
+#### Why two output heads
+
+The heads do not create separate actors or a sequential second decision. They
+make two semantically different action factors explicit, permit different
+initial biases, allow trade-only masking when association is absent, and keep
+trade versus allocation likelihood/KL inspectable. A single three-output diagonal
+Gaussian could be split manually, but would provide no advantage and would
+make these contracts easier to violate accidentally.
+
+#### Why centred allocation coordinates
+
+The simpler reference-logit map `softmax([z_1, z_2, 0])` has two degrees of
+freedom, but its sampled distribution is not symmetric: the reserve logit has
+no exploration noise, so zero means do not give equal expected allocation at
+non-zero variance. The orthonormal zero-sum contrast above keeps the same two
+degrees of freedom while treating growth, reproduction, and reserve
+exchangeably at initialisation. It is still a one-to-one map between two
+latent coordinates and the interior of the simplex.
+
+#### Why latent PPO likelihoods
+
+The current Gaussian sample is clipped and renormalised before execution, so
+many sampled actions map to the same physical allocation while PPO scores the
+untransformed Gaussian. Retaining the three latent samples makes the
+probability ratio correspond exactly to the stochastic decision that generated
+the deterministic physical action.
+
+The likelihood ratio and KL may be computed in latent space because the
+sigmoid and centred-simplex transforms are fixed bijections: their Jacobian
+terms cancel between the old and new policies for the same sampled action.
+
+Set the entropy-bonus coefficient to zero in the walking skeleton. Initial
+Gaussian scales provide exploration without introducing transformed-density
+and additional sampling machinery into the first implementation. Do not apply
+latent Gaussian entropy as a substitute because it can reward large latent
+variance while physical sigmoid/softmax actions concentrate near boundaries.
+A correctly Jacobian-adjusted physical-action entropy bonus remains a future
+extension if exploration collapse becomes an observed problem.
+
+### 7. Rollout validity, death, and sample masking
+
+For each species, trajectories must carry enough information to distinguish:
+
+- critic-valid pre-death state;
+- allocation action actually executed;
+- trade action actually active;
+- per-agent biological termination;
+- administrative truncation;
+- final pre-reset observation or its bootstrap value;
+- reset boundary.
+
+The environment expresses lifecycle through each per-agent `Transition` using
+`operational_at_start` and `operational_at_end`. The PPO transition adapter
+derives:
+
+```text
+critic_valid = operational_at_start
+terminated = operational_at_start AND NOT operational_at_end
+allocation_actor_valid = allocation_executed
+trade_actor_valid = trade_executed
+```
+
+`truncated` and `final_observation` are consumed directly from the same
+per-agent `Transition`; they remain environment facts, not PPO masks.
+
+Retain the transition in which maintenance causes death for critic/value
+learning, but do not apply an actor loss to an action the environment did not
+execute. Exclude every later dead-agent sample from actor loss, critic loss,
+advantage normalisation, and learning aggregates.
+
+Normalise advantages using actor-valid samples for that species only. Use safe
+masked reductions for actor and value losses. Keep the existing single
+actor-critic optimiser per species. If a minibatch has no actor-valid samples,
+skip the entire species update so Adam momentum cannot move inactive policy
+parameters; a rare isolated critic-only death target may therefore be omitted
+in the walking skeleton. Record actor-valid, trade-active, and critic-valid
+sample counts or fractions per species so obligate fungal mortality cannot
+silently starve its policy of data.
+
+#### Why per-species masks matter
+
+The fungus is obligately dependent on association while the plant is
+facultative. Fungal death may systematically occur earlier, leaving many fixed
+API steps in which only the plant acts. Padding fungal learning with inert
+post-death transitions would bias its critic and entropy objective rather than
+representing useful experience.
+
+### 8. Termination, truncation, and discounting
+
+Expose distinct concepts:
+
+```text
+terminated[agent] = biological death for that agent
+truncated = arbitrary maximum step reached
+reset = all configured agents dead OR truncated
+```
+
+The inherited JaxMARL `MultiAgentEnv.step` auto-resets and returns reset state
+and observation when `dones["__all__"]` is true. Preserve the final pre-reset
+observation in `info` (or an equivalently tested JAX-compatible return field)
+before auto-reset so PPO never bootstraps from the reset observation.
+
+For agent `i`, compute:
+
+```text
+delta_i = reward_i + gamma * (1 - terminated_i) * final_or_next_value_i - value_i
+```
+
+Stop the recursive GAE trace at either biological termination or
+administrative truncation so the reset episode's rewards are not mixed into
+the preceding trace. At truncation, the delta still bootstraps from the final
+pre-reset observation. At death, bootstrap value is zero.
+
+Use undiscounted cumulative reproductive fitness by default:
+
+```text
+gamma = 1.0
+discount_half_life_days = infinity / None
+```
+
+Provide one authoritative helper/configuration path for optional physical-time
+discount sensitivity:
+
+```text
+gamma = exp(-log(2) * env.config.dt / half_life_days)
+```
+
+Support the previously selected future sensitivity values of 30, 90, 365 days,
+and infinity, but do not run the empirical sensitivity study in this walking
+skeleton plan.
+
+The undiscounted, time-limit-bootstrapped objective is valid only as a proper
+episodic problem with finite expected lifetime return. Under the walking
+skeleton, strictly positive P maintenance and death thresholds for each active
+organism, positive initial biomass, and a finite closed P supply make eventual
+maintenance-deficit death unavoidable. Validate that condition when
+`gamma == 1`. If a future configuration permits zero P maintenance, a zero
+death threshold, external P replenishment, or another indefinitely viable
+trajectory, it must use a genuine biological terminal horizon, a finite
+discount, or a separately designed average-reward formulation.
+
+#### Why distinguish termination and truncation
+
+Death removes all future reproductive opportunity and must not bootstrap. The
+current maximum-step limit is arbitrary: treating it as death would make
+healthy biomass, reserves, and association suddenly worthless and could induce
+end-of-window liquidation strategies. Truncation inserts a training boundary,
+not a biological event.
+
+#### Why default to undiscounted fitness
+
+The reward is a reproductive-fitness index accumulated over the organism's
+life. Mortality already removes future fitness. Without a calibrated external
+mortality or demographic-compounding model, an additional finite discount
+would impose an otherwise unsupported preference for earlier reproduction.
+
+## Assumptions
+
+- There remains exactly one plant policy and one fungal policy under the fixed
+  two-agent JaxMARL API.
+- `EnvConfig.dt = 0.025 day` is both the numerical and actor decision interval
+  in the walking skeleton.
+- Current species traits and units remain valid inputs for the observation and
+  maintenance calculations.
+- Plant biomass cap is a meaningful plant normalization reference.
+- Existing saturated hemispherical fungal geometry is the authoritative
+  biomass-to-radial-extent mapping.
+- For the undiscounted baseline, every active organism has positive initial
+  biomass, P maintenance, and death fraction, and the environment has finite
+  total P with no external P replenishment, making lifetime reproductive
+  return finite.
+- Cobb-Douglas output is a dimensionless or indexed proxy for reproductive
+  fitness, not conserved biomass.
+- Actor observations always use the five bounded biological transforms.
+  Qualification and diagnostic code reads raw quantities from `State` or
+  explicit `info` fields rather than changing the actor observation contract.
+- Existing policy parameter files and serialized `State` values are
+  development artifacts rather than stable external formats.
+- The current dirty worktree contains user-owned untracked
+  `technical-summaries/` content that this plan and its execution must not
+  modify unless separately requested.
+
+## Constraints
+
+- Preserve JAX/JIT/vmap compatibility; avoid Python data-dependent branches in
+  environment and loss kernels.
+- Keep PPO masks, GAE controls, advantages, value targets, and optimiser
+  concepts out of `BaseMycorMarl`. The environment reports only
+  an algorithm-independent typed `Transition`; loose diagnostics remain
+  separate.
+- Keep the public two-agent names `plant` and `fungus` and stable dictionary
+  structure required by JaxMARL.
+- Return the same typed per-agent `Transition` schema under fixed `plant` and
+  `fungus` keys in every consumer mode and lifecycle state. Duplicated
+  truncation flags must agree.
+- Preserve plant-only and fungus-only modes under the fixed two-agent API.
+- Keep all physical pools non-negative and all biological allocation within
+  the available post-maintenance budgets.
+- Require physical actions to satisfy their bounds and simplex invariant before
+  entering `BaseMycorMarl`; do not repair actions inside the environment.
+- Preserve the existing growth-before-uptake geometry convention and
+  next-step availability of newly acquired resources.
+- Do not silently load old policy parameters into the new observation/head
+  architecture.
+- Migrate all four-element action callers atomically because the old and new
+  vectors have the same shape but different meanings.
+- Preserve unrelated user changes and use focused, reviewable phases.
+- Use executable tests rather than comments as the authoritative correctness
+  record.
+
+## Proposed Approach
+
+Implement the contract from environment state outward, then update PPO only
+after the physical action and observation interfaces are independently tested.
+This ordering keeps biological accounting failures separate from policy-loss
+failures.
+
+1. Establish red tests and inventory all action/state/observation call sites.
+2. Add observation-memory and maintenance-loss state fields, then implement
+   the complete five-element observation contract.
+3. Refactor the environment transaction to automatic maintenance and the new
+   trade plus biological-simplex action.
+4. Add the pure PPO transition-conversion helper, then introduce the two-head latent policy,
+   factorised likelihoods, validity masks, and correct
+   termination/truncation bootstrapping.
+5. Migrate scripts/docs/callers, run the integrated PPO smoke test, and perform
+   a final review/fix pass.
+
+This is an atomic development migration rather than a compatibility rollout.
+The action vector shape remains `(4,)`, so accepting old ordering would be more
+dangerous than failing explicitly. Update all repository callers in the same
+phase and document that saved state/policy artifacts must be regenerated.
+
+## Implementation Phases
+
+### P0 — Baseline contracts and migration inventory
+
+- Run the existing full suite and record the baseline result and warning set.
+- Inventory every `State` constructor/replacement, observation assumption,
+  `EnvConfig.norm_obs` use, action vector, action-index enum use, PPO
+  trajectory field, and saved-policy entry point.
+- Add or adapt focused tests that fail on the old behavior for:
+  - five bounded observations and exact feature order;
+  - state-only reconstruction of last received trade;
+  - the new independent trade plus biological-simplex contract;
+  - automatic maintenance and maintenance-P accounting;
+  - maintenance-death trade cancellation;
+  - inert corpse behavior;
+  - latent-to-physical policy transformations;
+  - death versus truncation bootstrap masks.
+- Record explicit checkpoint incompatibility and the old/new four-action
+  ordering in the phase handoff before changing source behavior.
+
+**Exit gate:** The existing baseline is known, every affected caller is listed,
+and red tests express the new contract without unrelated failures.
+
+### P1 — State-backed bounded observations
+
+- Add last-received trade and cumulative maintenance-P loss fields to `State`.
+- Update every state constructor, reset fixture, replacement, and balance
+  helper for the expanded dataclass.
+- Implement reusable non-negative saturating-ratio helpers with `OBS_EPS`.
+- Implement plant and fungal biomass scales, including the fungal radial-fill
+  inverse of the current geometry traits.
+- Replace `_get_obs(state, last_trade=...)` with state-only observation
+  construction.
+- Add the association feature, dead/absent zero mask, float32 cast, and `(5,)`
+  observation spaces with fixed bounds `[0,1]`.
+- Remove `EnvConfig.norm_obs` and migrate qualification/tests that set it;
+  obtain raw diagnostic quantities from `State` or explicit `info` fields.
+
+**Exit gate:** Reset and transition observations are reconstructable from
+`State`, finite, correctly ordered, bounded, species-scaled, JIT-compatible,
+and covered at zero and extreme inputs.
+
+### P2 — Automatic maintenance and compact physical resource transaction
+
+- Replace the action enum/order with
+  `[trade, growth, reproduction, reserve]`, add the shared public constructor,
+  and keep optional validation outside the compiled environment path.
+- Move maintenance demand/payment/deficit ahead of learned allocation for both
+  species and remove maintenance allocation from policy-controlled code.
+- Accumulate paid maintenance P in the new explicit loss counters.
+- Resolve sticky death before trade; cancel bilateral transfer if either
+  partner dies during maintenance.
+- Apply outgoing trade only to plant C or fungal P, then apply the same
+  growth/reproduction/reserve simplex separately to remaining C and P.
+- Preserve essential-resource realised growth, return non-limiting leftovers,
+  preserve Cobb-Douglas fitness reward, and keep incoming resources delayed.
+- Freeze all dead-agent state and active effects according to the corpse
+  contract.
+- Update `info` diagnostics to report automatic maintenance, requested and
+  realised action components, cancelled trade, association, and new P loss.
+- Migrate every test, example, qualification helper, and script action vector
+  atomically to the new ordering.
+
+**Exit gate:** Focused environment tests prove no overdraft, correct ordering,
+maintenance-P closure, trade cancellation, reserve behavior, delayed incoming
+resources, inert death, independent consumer modes, JIT, and vmap.
+
+### P3 — Two-head IPPO policy, valid-sample losses, and boundary semantics
+
+- Refactor `ActorCritic` to a shared encoder with separate trade and allocation
+  latent distributions plus the independent local critic.
+- Implement exact initial location biases, equal allocation scales, the
+  orthonormal zero-sum allocation contrast, and non-saturating exploration
+  scales.
+- Add one deterministic latent-to-physical transformation helper with tests.
+- Keep sampling, transformation, and trajectory storage explicit in the
+  rollout loop; do not introduce a policy-sample wrapper type.
+- Extend trajectories to store latent actions, physical actions, factorised old
+  log-probabilities, action-valid/trade-active/critic-valid masks,
+  termination, truncation, and bootstrap observation/value data.
+- Add one small pure PPO helper that converts the typed `Transition` into
+  trajectory fields and derives every PPO validity/bootstrap/trace mask. Do
+  not introduce an adapter class or derive/name PPO masks inside
+  `BaseMycorMarl`.
+- Populate every per-agent `Transition` with start/end operational status,
+  allocation/trade execution, truncation, and the final pre-reset observation.
+- Preserve final pre-reset observations through JaxMARL auto-reset.
+- Replace the current GAE `done` mask with separate bootstrap and trace masks.
+- Implement masked advantage normalisation, actor/value reductions, and a
+  whole-species no-actor-sample update guard separately for plant and fungus.
+- Keep one actor-critic optimiser per species and set the walking-skeleton
+  entropy coefficient to zero.
+- Mask trade likelihood when association is absent or bilateral trade is
+  cancelled by maintenance death; mask both actor factors only for the
+  organism whose learned allocation cannot execute.
+- Make undiscounted fitness the default and add tested physical-half-life to
+  per-step-gamma conversion without running the deferred empirical study;
+  reject or clearly fail an undiscounted configuration that violates the
+  proper-episode condition.
+- Update batching/minibatching to preserve environment dimensions and all new
+  masks under `NUM_ENVS > 1`.
+
+**Exit gate:** Unit and integration tests prove transformed physical actions,
+factorised likelihoods, initial trade median/allocation exchangeability,
+masked losses and whole-update guards, per-agent death handling,
+final-observation truncation bootstrap, and finite JIT PPO updates for one and
+multiple environments.
+
+### P4 — Integration, compatibility documentation, and verified handoff
+
+- Update `scripts/train_ppo.py`, README examples, docstrings, and any public
+  action/observation documentation.
+- Make saved parameter output identify the new actor-interface version or fail
+  clearly when an incompatible old parameter tree is supplied.
+- Run the required walking-skeleton tests, focused regression groups, and the
+  complete suite.
+- Run a small reproducible JIT PPO training smoke job and verify finite
+  parameters, losses, observations, rewards, actions, and values.
+- Check default mixed mode plus plant-only and fungus-only API stability.
+- Review the final diff for stale action ordering, out-of-band trade memory,
+  unmasked dead samples, reset-observation bootstrapping, and P-accounting
+  omissions; fix findings and repeat verification.
+- Document deferred extensions and avoid presenting smoke success as evidence
+  of convergence, robustness, cooperation, or biological validity.
+
+**Exit gate:** All required tests and smoke commands pass, documentation and
+examples match the implemented interface, old artifacts cannot load silently,
+and no actionable review finding remains.
+
+## Validation Plan
+
+### Required executable correctness tests
+
+- **Observation bounds:** reset, ordinary, zero-pool, high-pool, unassociated,
+  absent, and dead observations are finite float32 vectors of shape `(5,)`;
+  actor observations lie in `[0,1]`.
+- **Observation meaning:** plant/fungal biomass reference points, reserve
+  ratios, maintenance-need trade ratios, association, and feature order match
+  their equations.
+- **State reconstruction:** `_get_obs(state)` reproduces received-trade
+  observations after reset, ordinary trade, no trade, partner death, and saved
+  state round-trip.
+- **Action constraints:** the PPO transform and shared public constructor
+  produce finite actions with trade in `[0,1]` and non-negative biological
+  fractions summing to one; `BaseMycorMarl` receives and executes those values
+  unchanged. The explicit debug validator rejects invalid inputs.
+- **Budget safety:** automatic maintenance, trade, growth, reproduction, and
+  reserve never overdraw C or P; non-limiting growth allocation returns to its
+  pool.
+- **Maintenance P:** only paid maintenance P enters the plant/fungal counters;
+  unmet demand and reproduction/mortality remain separately accounted.
+- **Death:** maintenance-caused death cancels both trade directions, surviving
+  partners retain proposed transfers, corpse pools freeze, active geometry and
+  uptake disappear, rewards/actions become inert, and the survivor continues.
+- **Timing:** received trade, photosynthate, and uptake cannot fund allocation
+  until the next environment step.
+- **Policy transform:** trade initial median is 0.1; the allocation location
+  transforms to the uniform simplex; the zero-sum contrast is orthonormal and
+  permutation-symmetric with equal initial scales; latent and physical shapes
+  are correct; physical actions satisfy constraints without clipping.
+- **PPO likelihood:** recomputed factor log-probabilities match stored latent
+  samples; inactive trade is excluded; valid allocation remains trainable.
+- **Sample validity:** death-causing critic samples remain, unexecuted/dead
+  actor samples are masked and post-death value samples are excluded. A
+  minibatch with no actor-valid samples skips the complete species update and
+  leaves parameters/optimiser state unchanged. If one partner dies during
+  maintenance, the survivor's cancelled trade is masked but its executed
+  allocation remains actor-valid.
+- **Lifecycle derivation:** operational-to-non-operational means biological
+  termination; non-operational at both boundaries means absent/dead padding;
+  operational at both boundaries remains critic-valid.
+- **Termination/truncation:** death uses zero bootstrap; administrative
+  truncation uses the final pre-reset value; GAE stops at both and never uses
+  the reset observation or reset episode reward.
+- **Discount conversion:** infinity/None gives `gamma=1`; selected finite
+  half-lives produce the expected per-step values from physical `dt`; an
+  undiscounted configuration without guaranteed finite lifetime is rejected.
+- **PPO smoke:** one-update JIT training succeeds with one and at least two
+  environments; parameter trees, losses, returns, and actions are finite.
+
+### Verification commands
+
+Use the repository's managed environment and record exact output during
+execution. At minimum:
+
+```bash
+uv run pytest -q tests/test_actions.py
+uv run pytest -q tests/test_base_mycor_refactor.py tests/test_review_repairs.py
+uv run pytest -q
+uv run python scripts/train_ppo.py --total-timesteps 256 --num-steps 128 --num-envs 1
+```
+
+Add focused commands for new observation, termination/truncation, and PPO
+policy tests once their final file names are chosen.
+
+### Deferred validation
+
+Do not treat the following as exit gates for this plan: multi-seed convergence
+curves, cross-play, heuristic or adversarial partners, optimal-strategy claims,
+discount-half-life strategy comparisons, separate control intervals, spatial
+saturation experiments, or broad scientific calibration. Preserve them in the
+working diary for a later evaluation plan.
+
+## Compatibility and Rollout
+
+- This is a breaking development migration for environment state, observation
+  shape, observation configuration, action meaning, trajectory schema, and
+  PPO parameter trees.
+- Update all repository callers atomically. Do not provide an automatic adapter
+  from the old four-action vector because the unchanged shape makes silent
+  semantic conversion unsafe.
+- Regenerate serialized policy parameters and any saved environment state.
+- Keep the change in phase-sized commits or equivalent reviewable checkpoints
+  so source and tests can be reverted together if a phase fails verification.
+- Preserve the fixed agent dictionary/API and consumer modes so external
+  JaxMARL orchestration changes only where the new state/action/observation
+  contracts require it.
+
+## Risks
+
+- **Silent action-order compatibility:** old and new actions both have shape
+  `(4,)`. Missing one caller could silently reinterpret maintenance as
+  reproduction or reserve. Mitigate with atomic inventory/migration and named
+  helpers/enums in P0–P2.
+- **Incorrect PPO density:** scoring transformed physical fractions as
+  Gaussian latents would recreate the current likelihood mismatch. Mitigate
+  with stored latent actions and latent PPO ratios/KL.
+- **Invalid direct callers:** the environment no longer repairs malformed
+  arrays. Mitigate by migrating all repository callers to one public physical
+  action constructor and testing exact unchanged passage through the
+  environment boundary.
+- **Auto-reset bootstrap error:** JaxMARL returns reset observations at global
+  boundaries. Mitigate by preserving and testing final observations before
+  auto-reset.
+- **Outcome-dependent action masking:** maintenance may kill an agent before
+  its sampled action executes. Mitigate with explicit environment-reported
+  execution facts, a tested pure PPO conversion helper, and separate critic
+  versus actor validity.
+- **Boundary semantic drift:** environment facts and PPO masks could evolve
+  independently and silently disagree. Mitigate with adapter contract tests
+  covering ordinary action, absent association, maintenance death, survivor
+  continuation, biological termination, and truncation.
+- **Duplicated joint boundary:** per-agent `Transition` instances both carry
+  administrative truncation. Enforce equality as an environment invariant and
+  fail focused tests if the two instances disagree.
+- **Fungal sample starvation:** obligate fungal dependence may create many
+  post-death API steps. Mitigate correctness-wise with valid-sample counts,
+  masked reductions, and empty-batch guards; broader training responses remain
+  deferred.
+- **No entropy bonus:** initial Gaussian exploration may narrow prematurely.
+  Monitor action scales and defer Jacobian-adjusted physical-action entropy
+  unless exploration collapse is actually observed.
+- **Undiscounted critic variance:** `gamma=1` can be harder to estimate over
+  long horizons. Preserve it as the scientific objective and defer tuning of
+  GAE/rollout/value architecture unless the smoke test becomes numerically
+  invalid.
+- **Improper undiscounted return:** later enabling zero P maintenance, a zero
+  death threshold, or external P replenishment could permit endless positive
+  reward, for which time-limit bootstrapping with `gamma=1` has no finite value
+  target. Guard the current proper-episode assumptions and require an explicit
+  alternative objective when they no longer hold.
+- **Single-timestep action semantics:** stock fractions are chosen every
+  `0.025 day`, so reserve and spending behavior remain tied to that interval.
+  This is an accepted walking-skeleton limitation; separate control intervals
+  remain deferred.
+- **Maintenance-P simplification:** treating all paid P as external loss omits
+  recycling and repair. The explicit counter makes the approximation auditable.
+- **Cobb-Douglas interpretation:** the reward discounts imbalance but does not
+  impose hard reproductive stoichiometry. It must remain documented as a
+  fitness index, not physical offspring biomass.
+- **Corpse sequestration:** inert retained resources are unavailable forever
+  within an episode. This avoids invented decomposition but can affect long
+  surviving-partner trajectories.
+- **Fixed epsilon:** `1e-8` has different physical meaning across units. It is
+  accepted only as a numerical zero guard under current scales.
+- **Raw observation compatibility:** removing `EnvConfig.norm_obs` requires
+  migration of qualification fixtures and scripts that currently set it.
+  Mitigate by reading raw diagnostics from `State`/`info`, keeping one
+  invariant bounded actor interface instead of two observation meanings.
+- **No broad policy validation:** passing this plan demonstrates interface and
+  numerical correctness, not convergence, robust mutualism, or biological
+  optimality.
+
+## Success Criteria
+
+- Default plant and fungal observations are finite bounded `(5,)` vectors with
+  the agreed biological meaning and state-backed trade memory.
+- Environment physical actions are `[trade, growth, reproduction, reserve]`,
+  with independent trade and an exact three-part simplex generated from three
+  PPO latents.
+- Automatic maintenance is paid before allocation; maintenance P is explicitly
+  accounted; maintenance-caused death cancels bilateral trade.
+- No transition overdraws a resource pool, and incoming resources remain
+  unavailable until the next step.
+- Dead agents remain completely inert while surviving partners continue.
+- PPO uses separate trade/allocation output heads, exact factorised latent
+  likelihoods, centred exchangeable allocation exploration, valid-sample
+  masks, and the agreed initial policy. The walking skeleton uses no entropy
+  bonus.
+- Biological death and administrative truncation produce the correct distinct
+  bootstrap and trace behavior even through JaxMARL auto-reset.
+- Default training uses `gamma=1`; finite physical half-life conversion is
+  configurable and unit-tested.
+- All required focused tests, the complete repository suite, JIT/vmap checks,
+  and minimal one-/multi-environment PPO smoke tests pass without non-finite
+  values.
+- Scripts and documentation match the implemented interface, and old policy or
+  state artifacts cannot be mistaken for compatible new artifacts.
+- Deferred evaluation and scientific extensions remain explicitly documented
+  rather than being implied by walking-skeleton completion.
+
+## Open Questions
+
+No behavioral question blocks implementation planning.
+
+The plan-wide execution route also remains `undecided` until the human selects
+`standard`, `constrained`, or `undecided` for execution.

--- a/docs/model-overview.md
+++ b/docs/model-overview.md
@@ -69,8 +69,10 @@ geometry and boundary behaviour are tested in
 ## Coupling pipeline
 
 ```text
-start-of-step organism pools + allocation actions
-  -> trade, stoichiometric growth, maintenance and reproduction
+start-of-step organism pools + Physical actions
+  -> automatic maintenance and maintenance-deficit mortality
+  -> bilateral trade, or cancellation after maintenance death
+  -> stoichiometric growth, reproduction and reserve
   -> surviving biomass and mortality/export accounting
   -> photosynthetic C fixation
   -> biomass-derived root and hyphal density on the shared grid
@@ -164,9 +166,8 @@ mortality and reproduction are explicit exports from the represented system.
   represented.
 - **Limitation:** Mortality P leaves the system and reproduction P is exported;
   there is no litter, mineralisation, or recycling pool.
-- **Limitation:** Maintenance P is removed from free pools but has no explicit
-  destination, so whole-system P conservation must not be claimed for
-  maintenance-active trajectories.
+- **Limitation:** Paid maintenance P is represented as an external
+  maintenance/turnover loss rather than a recyclable biological or soil pool.
 - **Interpretation:** The shared grid is a coupling abstraction, not a claim
   that root and fungal architectures are physically continuous at all scales.
 

--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -35,7 +35,7 @@ configuration and organism traits
 | `fungus/mycelium.py` | Converts fungal biomass to a volume-averaged saturated hemispherical hyphal field. | Reset and post-growth geometry refresh. |
 | `plant/traits.py`, `fungus/traits.py` | Organism stoichiometry, kinetics, geometry, maintenance, and initial pools. | Biological and soil calculations. |
 | `growth.py`, `maintenance.py` | Shared realised-growth and maintenance calculations. | Plant and fungal environment steps. |
-| `observations.py` | Optional numerical normalisation for policy observations. | Environment observation construction. |
+| `observations.py` | Finite bounded transforms for the stable five-feature actor observations. | Environment observation construction. |
 | `algos/ppo.py` | Two-policy PPO integration using the `plant` and `fungus` interfaces. | Training launcher and experiments. |
 
 ## Executable and evidence modules
@@ -50,6 +50,7 @@ configuration and organism traits
 | `tests/test_environment_phosphate_uptake.py` | Protects soil-to-organism pool credit, competition, loss accounting, and environment integration. |
 | `tests/test_growth_geometry.py` | Protects biomass-to-length and spatial conservation rules. |
 | `tests/test_base_mycor_refactor.py` | Protects environment ordering, death, trade, growth, and observations. |
+| `tests/test_actor_observations.py` | Protects actor feature meaning, bounds, state reconstruction, lifecycle masking, JIT, and vectorisation. |
 | `tests/test_review_repairs.py` | Protects public entry points, independent modes, PPO integration, and repaired regressions. |
 
 ## Key ownership boundaries

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -6,12 +6,6 @@ verification records are retained under [`archive/`](archive/).
 
 ## Phosphorus accounting
 
-- **Maintenance-P accounting implementation:** current maintenance removes P
-  from the free organism pool without assigning it to structure, recycling,
-  soil, or a loss diagnostic. The agreed next treatment is to record it as an
-  explicit unmodelled maintenance/turnover loss in separate plant and fungal
-  counters. Until that change is implemented and tested, whole-system
-  conservation must not be claimed for maintenance-active runs.
 - **Mortality and recycling:** structural P lost through mortality is recorded
   as leaving the simulated system. Decide whether litter, mineralisation, and
   re-uptake pools are needed for the intended experiments.

--- a/docs/qualification/phosphate-numerical-qualification.md
+++ b/docs/qualification/phosphate-numerical-qualification.md
@@ -69,6 +69,6 @@ The selection uses a 5% next-finer/next-smaller comparison on fixed-geometry upt
 - No scientific matrix row was inventory-capped. Fixed-soil outputs changed by less than 0.5% across the timestep candidates, but endpoint coupled free-P pools changed by approximately 98–102%; none of the coarser timestep candidates passed the 5% gate.
 - 0.025 day is the finest tested timestep and was selected as the fallback. Because it has no finer reference, this result does not demonstrate timestep convergence; a finer follow-up study or a revised scientifically justified endpoint metric is required.
 - Reduced-domain convergence retains a topsoil diffusion front but cannot reproduce every full-domain spatial scale.
-- Coupled actions are fixed at `[trade=0.25, growth=0.75, maintenance=0, reproduction=0]`; maintenance costs are disabled only in this qualification fixture so the unresolved maintenance-P fate cannot contaminate balance interpretation.
+- Coupled Physical actions are fixed at `[trade=0.25, growth=1, reproduction=0, reserve=0]`; automatic maintenance costs are disabled in this fixture to isolate timestep sensitivity in growth and uptake.
 - Annual runtime is projected from both warmed soil-only and deterministic full-environment steps. MARL training, learned-policy inference, output, and accelerator transfer costs are excluded.
 - The complete machine-readable tables and exact platform metadata are in `phosphate-numerical-qualification.json`.

--- a/docs/technical-summaries/phosphate-numerical-qualification.md
+++ b/docs/technical-summaries/phosphate-numerical-qualification.md
@@ -306,9 +306,9 @@ Refinement is not the only requirement. Every scenario also reports or tests:
 
 The executable contracts are in
 [`tests/test_phosphate_qualification.py`, lines 61–280](../tests/test_phosphate_qualification.py#L61-L280).
-The present coupled balance fixture sets maintenance demand and allocation to
-zero because maintenance P still lacks an explicit destination. Its successful
-balance must not be generalized to maintenance-active trajectories.
+The present coupled balance fixture sets maintenance demand to zero so the
+timestep comparison isolates growth and uptake. Paid maintenance P now has
+explicit plant and fungal loss counters and is included in the extended ledger.
 
 ## Performance qualification
 

--- a/docs/technical-summaries/phosphorus-conservation-and-accounting.md
+++ b/docs/technical-summaries/phosphorus-conservation-and-accounting.md
@@ -173,6 +173,7 @@ P_{\mathrm{extended}}={}&
 +P_{p,\mathrm{free}}+P_{f,\mathrm{free}}\\
 &+\gamma_{P,p}G_p+\gamma_{P,f}G_f\\
 &+P_{\mathrm{mortality,cumulative}}
++P_{\mathrm{maintenance,cumulative}}
 +P_{\mathrm{reproduction,cumulative}}.
 \end{aligned}
 \]
@@ -183,45 +184,30 @@ Fungal-to-plant P trade is internal: the same `fungus_p_trade_out` is added to
 the plant pool and subtracted from the fungal pool
 ([`base_mycor.py`, lines 287–295](../mycormarl/mycormarl/environments/base_mycor.py#L287-L295);
 [`base_mycor.py`, lines 349–357](../mycormarl/mycormarl/environments/base_mycor.py#L349-L357)).
-Reproduction and mortality are not treated as disappearing silently; cumulative
-counters retain their amounts in the ledger
+Reproduction, mortality, and paid maintenance P are not treated as disappearing
+silently; cumulative counters retain their amounts in the ledger
 ([`base_mycor.py`, lines 358–373](../mycormarl/mycormarl/environments/base_mycor.py#L358-L373)).
 
 The extended-balance qualification test verifies closure to relative tolerance
 \(10^{-5}\)
 ([`test_phosphate_qualification.py`, lines 263–279](../tests/test_phosphate_qualification.py#L263-L279)).
-However, its fixture sets both maintenance coefficients to zero and uses zero
-maintenance allocation
+Its fixture sets both maintenance coefficients to zero
 ([`phosphate_qualification.py`, lines 43–61](../scripts/phosphate_qualification.py#L43-L61);
 [`phosphate_qualification.py`, lines 275–279](../scripts/phosphate_qualification.py#L275-L279)).
-It therefore proves conservation for that defined pathway, not for arbitrary
-agent actions.
+This isolates growth and uptake sensitivity; maintenance-active closure is
+covered separately by focused environment tests.
 
-## 5. Why maintenance prevents a general whole-system claim
+## 5. How paid maintenance P closes the extended ledger
 
-For both organisms, `maint_p_used` is included in total P use and deducted from
-the free pool
+For both organisms, `maint_p_used` is deducted automatically from the
+start-of-step free pool
 ([`base_mycor.py`, lines 519–545](../mycormarl/mycormarl/environments/base_mycor.py#L519-L545);
 [`base_mycor.py`, lines 617–643](../mycormarl/mycormarl/environments/base_mycor.py#L617-L643)).
-Unlike reproduction and mortality P, it is not:
-
-- transferred to another modeled pool;
-- returned to the soil;
-- incorporated into additional structural biomass; or
-- accumulated in an explicit maintenance/turnover loss counter.
-
-Accordingly, \(P_{\mathrm{extended}}\) falls by `maint_p_used` in a
-maintenance-active step. This is not a diffusion error or an uptake error. It is
-an incomplete biological fate specification. Until a scientific destination is
-chosen and represented, the precise statement is:
-
-> Diffusion, competition, uptake credit, trade, growth, recorded mortality, and
-> recorded reproduction obey their local or extended accounting contracts.
-> Whole-system P conservation is not established for maintenance-active
-> trajectories.
-
-The distinction matters because a strict balance test is useful precisely when
-it exposes an omitted store or flux rather than concealing it.
+The amount actually paid is accumulated in the species-specific
+`cumulative_*_p_maintenance_loss_mg` counter. Unmet demand is not added to this
+counter; it drives deterministic biomass loss instead. Treating paid P as an
+external maintenance/turnover loss closes the extended diagnostic ledger
+without claiming recycling into a biological or soil compartment.
 
 ## Relationship to the literature
 
@@ -255,7 +241,8 @@ it exposes an omitted store or flux rather than concealing it.
   inventory using solution concentration as the driving potential.
 - Numerical conservation is subject to floating-point round-off and the stated
   test tolerances.
-- The current qualification evidence does not cover non-zero maintenance P use.
+- Paid maintenance P is treated as an external loss rather than recycled into
+  soil or another biological compartment.
 
 ## Practical interpretation
 
@@ -265,4 +252,3 @@ beside competing uptake, read it as exact allocation of a finite cell inventory.
 For a whole simulation, use the extended ledger and state its boundary and
 export conventions explicitly. Under the current code, add the qualification
 that maintenance P has an unresolved fate.
-

--- a/mycormarl/mycormarl/__init__.py
+++ b/mycormarl/mycormarl/__init__.py
@@ -5,10 +5,12 @@ from .soil import *
 from .fungus import *
 from .actions import *
 from .state import State
+from .transition import Transition
 from .params import EnvConfig, SpeciesParams
 
 __all__ = [
     "State",
+    "Transition",
     "EnvConfig",
     "SpeciesParams",
 ]

--- a/mycormarl/mycormarl/actions.py
+++ b/mycormarl/mycormarl/actions.py
@@ -3,34 +3,39 @@ import chex
 import jax.numpy as jnp
 
 
-def _check_action(action: chex.Array, n_parts: int = 4) -> chex.Array:
-    """Convert, sanitize, and clip an action vector.
+def physical_action(
+    trade: chex.Numeric,
+    growth: chex.Numeric,
+    reproduction: chex.Numeric,
+    reserve: chex.Numeric,
+) -> chex.Array:
+    """Construct ``[trade, growth, reproduction, reserve]``.
 
-    This intentionally avoids value-based Python checks so it remains compatible
-    with JAX transformations. The final allocation simplex is enforced by
-    ``_allocation_from_action``.
+    Trade is bounded independently; the remaining components are interpreted
+    as non-negative biological weights and normalised onto their simplex.
     """
-
-    action = jnp.asarray(action, dtype=jnp.float32)
-    if action.shape[-1] != n_parts:
-        raise ValueError(f"Expected action with {n_parts} components, got shape {action.shape}")
-
-    action = jnp.where(jnp.isfinite(action), action, 0.0)
-    return jnp.clip(action, 0.0, 1.0)
-
-def _allocation_from_action(action: chex.Array, n_parts: int = 4) -> chex.Array:
-    """Map an action vector to growth / maintenance / reproduction / trade weights.
-
-    The weights are renormalised internally to keep the resource accounting
-    stable even when the policy emits arbitrary values. If clipping and
-    sanitising leaves no positive allocation, return a uniform allocation.
-    """
-    a = _check_action(action, n_parts=n_parts)
-
-    total = jnp.sum(a, axis=-1, keepdims=True)
-    uniform = jnp.ones_like(a) / n_parts # Return uniform allocation if total is zero.
-    return jnp.where(total > 0.0, a / total, uniform)
-
-def constrain_allocation(action: chex.Array, n_parts: int = 4) -> chex.Array:
-    """Return a JIT-friendly allocation vector on the simplex."""
-    return _allocation_from_action(action, n_parts=n_parts)
+    trade_fraction = jnp.asarray(trade, dtype=jnp.float32)
+    trade_fraction = jnp.where(jnp.isfinite(trade_fraction), trade_fraction, 0.0)
+    trade_fraction = jnp.clip(trade_fraction, 0.0, 1.0)
+    biological_weights = jnp.stack(
+        [
+            jnp.asarray(growth, dtype=jnp.float32),
+            jnp.asarray(reproduction, dtype=jnp.float32),
+            jnp.asarray(reserve, dtype=jnp.float32),
+        ],
+        axis=-1,
+    )
+    biological_weights = jnp.where(
+        jnp.isfinite(biological_weights), biological_weights, 0.0
+    )
+    biological_weights = jnp.maximum(biological_weights, 0.0)
+    total = jnp.sum(biological_weights, axis=-1, keepdims=True)
+    biological_allocation = jnp.where(
+        total > 0.0,
+        biological_weights / total,
+        jnp.ones_like(biological_weights) / 3.0,
+    )
+    return jnp.concatenate(
+        [jnp.expand_dims(trade_fraction, axis=-1), biological_allocation],
+        axis=-1,
+    )

--- a/mycormarl/mycormarl/algos/ppo.py
+++ b/mycormarl/mycormarl/algos/ppo.py
@@ -10,6 +10,7 @@ from flax.training.train_state import TrainState
 import distrax
 import optax
 
+from mycormarl.actions import physical_action
 from mycormarl.environments.base_mycor import FUNGUS, PLANT
 
 
@@ -173,16 +174,28 @@ def make_train(env, config):
 
                 # Get actions from tree and fungus networks
                 tree_pi, tree_value = tree_policy.apply(train_state["plant"].params, tree_obs_batch)
-                tree_action = tree_pi.sample(seed=tree_act_rng)
-                tree_log_prob = tree_pi.log_prob(tree_action)
+                tree_latent_action = tree_pi.sample(seed=tree_act_rng)
+                tree_log_prob = tree_pi.log_prob(tree_latent_action)
+                tree_physical_action = physical_action(
+                    tree_latent_action[..., 0],
+                    tree_latent_action[..., 1],
+                    tree_latent_action[..., 2],
+                    tree_latent_action[..., 3],
+                )
 
                 fungus_pi, fungus_value = fungus_policy.apply(train_state["fungus"].params, fungus_obs_batch)
-                fungus_action = fungus_pi.sample(seed=fungus_act_rng)
-                fungus_log_prob = fungus_pi.log_prob(fungus_action)
+                fungus_latent_action = fungus_pi.sample(seed=fungus_act_rng)
+                fungus_log_prob = fungus_pi.log_prob(fungus_latent_action)
+                fungus_physical_action = physical_action(
+                    fungus_latent_action[..., 0],
+                    fungus_latent_action[..., 1],
+                    fungus_latent_action[..., 2],
+                    fungus_latent_action[..., 3],
+                )
 
                 # Unbatchify the actions to match the environment's expected input format
                 env_act = unbatchify(
-                    jnp.stack([tree_action, fungus_action]),
+                    jnp.stack([tree_physical_action, fungus_physical_action]),
                     env.agents, config.NUM_ENVS, config.NUM_ACTORS
                 )
 
@@ -195,7 +208,7 @@ def make_train(env, config):
                 # Collect Trajectory object
                 tree_transition = Trajectory(
                     done[PLANT].squeeze(),
-                    tree_action,
+                    tree_latent_action,
                     jnp.array(tree_value),
                     reward[PLANT].squeeze(),
                     tree_log_prob,
@@ -205,7 +218,7 @@ def make_train(env, config):
                 )
                 fungus_transition = Trajectory(
                     done[FUNGUS].squeeze(),
-                    fungus_action,
+                    fungus_latent_action,
                     jnp.array(fungus_value),
                     reward[FUNGUS].squeeze(),
                     fungus_log_prob,

--- a/mycormarl/mycormarl/environments/base_mycor.py
+++ b/mycormarl/mycormarl/environments/base_mycor.py
@@ -12,10 +12,8 @@ import jax
 import jax.numpy as jnp
 
 from mycormarl import fungus, plant
-from mycormarl.fungus.physiology import fungal_maintenance_demand
 from mycormarl.params import EnvConfig, SpeciesParams
 from mycormarl.growth import grow
-from mycormarl.plant.physiology import plant_maintenance_demand
 from mycormarl.soil import (
     axisymmetric_cylindrical_cell_volumes,
     axisymmetric_diffusion_conductances,
@@ -31,7 +29,6 @@ from mycormarl.soil import (
     validate_linear_buffer_parameters,
 )
 from mycormarl.plant import photosynthesise
-from mycormarl.actions import constrain_allocation
 from mycormarl.observations import actor_observation
 from mycormarl.state import State
 
@@ -45,11 +42,11 @@ FUNGUS = "fungus"
 AGENTS = (PLANT, FUNGUS)
 
 class Actions(IntEnum):
-    # Trade, growth, maintenance, reproduction fractions.
+    # Physical action: independent trade plus a biological allocation simplex.
     trade = 0
     growth = 1
-    maintenance = 2
-    reproduction = 3
+    reproduction = 2
+    reserve = 3
 
 
 class BaseMycorMarl(MultiAgentEnv):
@@ -123,14 +120,14 @@ class BaseMycorMarl(MultiAgentEnv):
         obs_dim = 5
 
         self.action_set = jnp.array(
-            [Actions.trade, Actions.growth, Actions.maintenance, Actions.reproduction]
+            [Actions.trade, Actions.growth, Actions.reproduction, Actions.reserve]
         )
 
         self.observation_spaces = {
             PLANT: Box(low=0.0, high=1.0, shape=(obs_dim,), dtype=jnp.float32),
             FUNGUS: Box(low=0.0, high=1.0, shape=(obs_dim,), dtype=jnp.float32),
         }
-        # Four continuous allocations: trade, growth, maintenance, reproduction.
+        # Physical action: trade, growth, reproduction, reserve.
         self.action_spaces = {
             PLANT: Box(low=0.0, high=1.0, shape=self.action_set.shape, dtype=jnp.float32),
             FUNGUS: Box(low=0.0, high=1.0, shape=self.action_set.shape, dtype=jnp.float32),
@@ -222,12 +219,15 @@ class BaseMycorMarl(MultiAgentEnv):
             self.config.b_p,
         )
 
+        # Positive initial biomass only if the organism is active.
         plant_biomass = jnp.array([
             self.species.plant.initial_biomass if self.plant_active else 0.0
         ])
         fungus_biomass = jnp.array([
             self.species.fungus.initial_biomass if self.fungus_active else 0.0
         ])
+
+        # Calculate root density fields from initial biomass.
         root_length_density = plant.density_field_from_biomass(
             plant_biomass,
             self.species.plant,
@@ -267,6 +267,8 @@ class BaseMycorMarl(MultiAgentEnv):
             hyphae_length_density=hyphae_length_density,
             cumulative_plant_p_mortality_loss_mg=jnp.array([0.0]),
             cumulative_fungus_p_mortality_loss_mg=jnp.array([0.0]),
+            cumulative_plant_p_maintenance_loss_mg=jnp.array([0.0]),
+            cumulative_fungus_p_maintenance_loss_mg=jnp.array([0.0]),
             cumulative_plant_p_reproduction_export_mg=jnp.array([0.0]),
             cumulative_fungus_p_reproduction_export_mg=jnp.array([0.0]),
             plant_dead=jnp.array([not self.plant_active]),
@@ -286,119 +288,164 @@ class BaseMycorMarl(MultiAgentEnv):
             state: State,
             actions: Dict[str, chex.Array]
         ) -> Tuple[Dict[str, chex.Array], State, Dict[str, float], Dict[str, bool], Dict]:
+        """Apply a valid Physical action to the environment state.
 
-        plant_operational = jnp.logical_and(
+        Checks plant/fungus operational status, pays maintenance, applies growth and
+        reproduction, and updates the soil P field. Returns the next observation, state,
+        rewards, dones, and infos. The labile P field is a conserved quantity.
+
+        # TODO: decrease root/hyphal density with biomass loss.
+        """
+        plant_operational_at_start = jnp.logical_and(
             self.plant_active, jnp.logical_not(state.plant_dead)
         )
-        fungus_operational = jnp.logical_and(
+        fungus_operational_at_start = jnp.logical_and(
             self.fungus_active, jnp.logical_not(state.fungus_dead)
         )
-        plant_actions = jnp.where(
-            plant_operational,
-            constrain_allocation(actions[PLANT]),
-            jnp.zeros_like(actions[PLANT]),
+
+        plant_maintenance = self._pay_maintenance(
+            state.plant_biomass,
+            state.plant_c_pool,
+            state.plant_p_pool,
+            self.species.plant,
+            plant_operational_at_start,
         )
-        fungus_actions = jnp.where(
-            fungus_operational,
-            constrain_allocation(actions[FUNGUS]),
-            jnp.zeros_like(actions[FUNGUS]),
+        fungus_maintenance = self._pay_maintenance(
+            state.fungus_biomass,
+            state.fungus_c_pool,
+            state.fungus_p_pool,
+            self.species.fungus,
+            fungus_operational_at_start,
         )
 
-        # Agents spend only the pools that were observable at the start of the
-        # timestep. Newly acquired resources are credited after allocation.
-        plant_c_start = state.plant_c_pool
-        plant_p_start = state.plant_p_pool
-        fungus_c_start = state.fungus_c_pool
-        fungus_p_start = state.fungus_p_pool
+        plant_biomass_after_maintenance = plant_maintenance["biomass"]
+        fungus_biomass_after_maintenance = fungus_maintenance["biomass"]
 
-        # Trade is an allocation choice on the same simplex as the other
-        # actions, but it only affects the traded currency for each partner.
-        trading_enabled = jnp.logical_and(plant_operational, fungus_operational)
-        plant_c_trade_out = jnp.where(
-            trading_enabled, plant_actions[Actions.trade] * plant_c_start, 0.0
-        )
-        fungus_p_trade_out = jnp.where(
-            trading_enabled, fungus_actions[Actions.trade] * fungus_p_start, 0.0
-        )
-
-        plant_step = self.step_plant(key, state, plant_actions)
-        fungus_step = self.step_fungus(key, state, fungus_actions)
-
-        plant_biomass_before_mortality = jnp.clip(
-            state.plant_biomass + plant_step["growth"],
-            0.0,
-            self.species.plant.biomass_cap,
-        )
-        fungus_biomass_before_mortality = jnp.clip(
-            state.fungus_biomass + fungus_step["growth"],
-            0.0,
-            jnp.inf,
-        )
-        plant_biomass = jnp.clip(
-            state.plant_biomass + plant_step["growth"] - plant_step["maint_deficit_biomass"],
-            0.0,
-            self.species.plant.biomass_cap,
-        )
-        fungus_biomass = jnp.clip(
-            state.fungus_biomass + fungus_step["growth"] - fungus_step["maint_deficit_biomass"],
-            0.0,
-            jnp.inf,
-        )
-        plant_mortality_biomass = jnp.maximum(
-            plant_biomass_before_mortality - plant_biomass, 0.0
-        )
-        fungus_mortality_biomass = jnp.maximum(
-            fungus_biomass_before_mortality - fungus_biomass, 0.0
-        )
-
-        plant_history_max = jnp.maximum(state.plant_history_max_biomass, plant_biomass)
-        fungus_history_max = jnp.maximum(state.fungus_history_max_biomass, fungus_biomass)
-
+        # Check biomass has not fallen below death threshold. If so, mark dead and zero pools.
         plant_dead = jnp.logical_or(
             state.plant_dead,
             jnp.logical_or(
                 not self.plant_active,
-                plant_biomass < (
-                self.species.plant.death_fraction * jnp.maximum(plant_history_max, 1e-8)
-                ),
+                plant_biomass_after_maintenance
+                < self.species.plant.death_fraction
+                * jnp.maximum(state.plant_history_max_biomass, 1e-8),
             ),
         )
         fungus_dead = jnp.logical_or(
             state.fungus_dead,
             jnp.logical_or(
                 not self.fungus_active,
-                fungus_biomass < (
-                self.species.fungus.death_fraction * jnp.maximum(fungus_history_max, 1e-8)
+                fungus_biomass_after_maintenance
+                < self.species.fungus.death_fraction
+                * jnp.maximum(state.fungus_history_max_biomass, 1e-8),
+            ),
+        )
+
+        # Re-check operational status after maintenance and death.
+        plant_operational_at_end = jnp.logical_and(
+            self.plant_active, jnp.logical_not(plant_dead)
+        )
+        fungus_operational_at_end = jnp.logical_and(
+            self.fungus_active, jnp.logical_not(fungus_dead)
+        )
+
+        # Bilateral trade is resolved after maintenance. If either organism died
+        # while paying maintenance, neither proposed transfer leaves its owner.
+        trading_enabled = jnp.logical_and(
+            plant_operational_at_end, fungus_operational_at_end
+        )
+        plant_c_trade_proposed = jnp.where(
+            plant_operational_at_start,
+            actions[PLANT][Actions.trade] * plant_maintenance["c_pool"],
+            0.0,
+        )
+        fungus_p_trade_proposed = jnp.where(
+            fungus_operational_at_start,
+            actions[FUNGUS][Actions.trade] * fungus_maintenance["p_pool"],
+            0.0,
+        )
+        plant_c_trade_out = jnp.where(
+            trading_enabled,
+            plant_c_trade_proposed,
+            0.0,
+        )
+        fungus_p_trade_out = jnp.where(
+            trading_enabled,
+            fungus_p_trade_proposed,
+            0.0,
+        )
+
+        # Add a flag to indicate whether a trade was proposed but cancelled due
+        # to one party dying or being non-operational.
+        trade_cancelled = jnp.logical_and(
+            jnp.logical_and(
+                plant_operational_at_start, fungus_operational_at_start
+            ),
+            jnp.logical_and(
+                jnp.logical_not(trading_enabled),
+                jnp.logical_or(
+                    plant_c_trade_proposed > 0.0,
+                    fungus_p_trade_proposed > 0.0,
                 ),
             ),
         )
 
-        state = state.replace(
+        # Update state with post-maintenance biomass and pools, then apply growth
+        # and reproduction.
+        allocation_state = state.replace(
+            plant_biomass=plant_biomass_after_maintenance,
+            fungus_biomass=fungus_biomass_after_maintenance,
+            plant_c_pool=plant_maintenance["c_pool"] - plant_c_trade_out,
+            plant_p_pool=plant_maintenance["p_pool"],
+            fungus_c_pool=fungus_maintenance["c_pool"],
+            fungus_p_pool=fungus_maintenance["p_pool"] - fungus_p_trade_out,
+            plant_dead=plant_dead,
+            fungus_dead=fungus_dead,
+        )
+        # Perform allocations.
+        plant_step = self.step_plant(key, allocation_state, actions[PLANT])
+        fungus_step = self.step_fungus(key, allocation_state, actions[FUNGUS])
+
+        plant_biomass = jnp.minimum(
+            plant_biomass_after_maintenance + plant_step["growth"],
+            self.species.plant.biomass_cap,
+        )
+        fungus_biomass = fungus_biomass_after_maintenance + fungus_step["growth"]
+        plant_history_max = jnp.maximum(state.plant_history_max_biomass, plant_biomass)
+        fungus_history_max = jnp.maximum(state.fungus_history_max_biomass, fungus_biomass)
+
+        state = allocation_state.replace(
             plant_biomass=plant_biomass,
             fungus_biomass=fungus_biomass,
             plant_history_max_biomass=plant_history_max,
             fungus_history_max_biomass=fungus_history_max,
-            plant_c_pool=jnp.clip(plant_step["c_pool"] - plant_c_trade_out, 0.0, jnp.inf),
+            plant_c_pool=plant_step["c_pool"],
             plant_p_pool=plant_step["p_pool"] + fungus_p_trade_out,
             fungus_c_pool=fungus_step["c_pool"] + plant_c_trade_out,
-            fungus_p_pool=jnp.clip(fungus_step["p_pool"] - fungus_p_trade_out, 0.0, jnp.inf),
+            fungus_p_pool=fungus_step["p_pool"],
             plant_last_p_received=jnp.where(
-                jnp.logical_and(self.plant_active, jnp.logical_not(plant_dead)),
-                fungus_p_trade_out,
-                0.0,
+                plant_operational_at_end, fungus_p_trade_out, 0.0
             ),
             fungus_last_c_received=jnp.where(
-                jnp.logical_and(self.fungus_active, jnp.logical_not(fungus_dead)),
-                plant_c_trade_out,
-                0.0,
+                fungus_operational_at_end, plant_c_trade_out, 0.0
             ),
             cumulative_plant_p_mortality_loss_mg=(
                 state.cumulative_plant_p_mortality_loss_mg
-                + plant_mortality_biomass * self.species.plant.gamma_p
+                + plant_maintenance["mortality_biomass"]
+                * self.species.plant.gamma_p
             ),
             cumulative_fungus_p_mortality_loss_mg=(
                 state.cumulative_fungus_p_mortality_loss_mg
-                + fungus_mortality_biomass * self.species.fungus.gamma_p
+                + fungus_maintenance["mortality_biomass"]
+                * self.species.fungus.gamma_p
+            ),
+            cumulative_plant_p_maintenance_loss_mg=(
+                state.cumulative_plant_p_maintenance_loss_mg
+                + plant_maintenance["p_used"]
+            ),
+            cumulative_fungus_p_maintenance_loss_mg=(
+                state.cumulative_fungus_p_maintenance_loss_mg
+                + fungus_maintenance["p_used"]
             ),
             cumulative_plant_p_reproduction_export_mg=(
                 state.cumulative_plant_p_reproduction_export_mg
@@ -408,8 +455,6 @@ class BaseMycorMarl(MultiAgentEnv):
                 state.cumulative_fungus_p_reproduction_export_mg
                 + fungus_step["reproduction_p"]
             ),
-            plant_dead=plant_dead,
-            fungus_dead=fungus_dead,
         )
 
         # New resources acquired during the transition are added after
@@ -458,19 +503,25 @@ class BaseMycorMarl(MultiAgentEnv):
         infos = {
             PLANT: {
                 **plant_step["info"],
+                **plant_maintenance["info"],
                 "biomass": state.plant_biomass,
                 "c_pool": state.plant_c_pool,
                 "p_pool": state.plant_p_pool,
+                "proposed_trade_out": plant_c_trade_proposed,
                 "trade_out": plant_c_trade_out,
                 "trade_in": fungus_p_trade_out,
+                "trade_cancelled": trade_cancelled,
             },
             FUNGUS: {
                 **fungus_step["info"],
+                **fungus_maintenance["info"],
                 "biomass": state.fungus_biomass,
                 "c_pool": state.fungus_c_pool,
                 "p_pool": state.fungus_p_pool,
+                "proposed_trade_out": fungus_p_trade_proposed,
                 "trade_out": fungus_p_trade_out,
                 "trade_in": plant_c_trade_out,
+                "trade_cancelled": trade_cancelled,
             },
         }
 
@@ -500,206 +551,129 @@ class BaseMycorMarl(MultiAgentEnv):
             self.config.uptake_transition_exponent,
         )
 
+    def _pay_maintenance(
+        self,
+        biomass: chex.Array,
+        c_pool: chex.Array,
+        p_pool: chex.Array,
+        traits,
+        operational: chex.Array,
+    ) -> dict:
+        """Pay unavoidable maintenance from start-of-step free pools."""
+        active_biomass = jnp.where(operational, biomass, 0.0)
+        required_c = traits.kappa_c * active_biomass * self.config.dt
+        required_p = traits.kappa_p * active_biomass * self.config.dt
+        c_used = jnp.minimum(c_pool, required_c)
+        p_used = jnp.minimum(p_pool, required_p)
+        c_deficit = required_c - c_used
+        p_deficit = required_p - p_used
+        mortality_biomass = jnp.maximum(
+            c_deficit / traits.gamma_c,
+            p_deficit / traits.gamma_p,
+        )
+        mortality_biomass = jnp.minimum(mortality_biomass, active_biomass)
+        return {
+            "biomass": jnp.where(
+                operational, biomass - mortality_biomass, biomass
+            ),
+            "c_pool": jnp.where(operational, c_pool - c_used, c_pool),
+            "p_pool": jnp.where(operational, p_pool - p_used, p_pool),
+            "p_used": p_used,
+            "mortality_biomass": mortality_biomass,
+            "info": {
+                "maint_c": required_c,
+                "maint_p": required_p,
+                "maint_c_used": c_used,
+                "maint_p_used": p_used,
+                "c_deficit": c_deficit,
+                "p_deficit": p_deficit,
+            },
+        }
+
+    def _apply_allocation(
+        self,
+        biomass: chex.Array,
+        c_pool: chex.Array,
+        p_pool: chex.Array,
+        action: chex.Array,
+        traits,
+        operational: chex.Array,
+        biomass_cap: float | None = None,
+    ) -> dict:
+        """Apply growth/reproduction/reserve fractions to disposable C and P."""
+        action = jnp.where(operational, action, jnp.zeros_like(action))
+        growth_alloc = action[Actions.growth]
+        reproduction_alloc = action[Actions.reproduction]
+
+        growth_c_alloc = growth_alloc * c_pool
+        growth_p_alloc = growth_alloc * p_pool
+        growth = grow(
+            allocated_c=growth_c_alloc,
+            allocated_p=growth_p_alloc,
+            grow_c_cost=traits.gamma_c,
+            grow_p_cost=traits.gamma_p,
+            grow_type="essential",
+        )
+        if biomass_cap is not None:
+            growth = jnp.minimum(
+                growth,
+                jnp.maximum(biomass_cap - biomass, 0.0),
+            )
+        growth_c_used = growth * traits.gamma_c
+        growth_p_used = growth * traits.gamma_p
+        reproduction_c = reproduction_alloc * c_pool
+        reproduction_p = reproduction_alloc * p_pool
+        remaining_c_pool = c_pool - reproduction_c - growth_c_used
+        remaining_p_pool = p_pool - reproduction_p - growth_p_used
+        reproduction_c_scaled = reproduction_c / traits.gamma_c
+        reproduction_p_scaled = reproduction_p / traits.gamma_p
+        reward = self._cobb_douglas(reproduction_c_scaled, reproduction_p_scaled, self.config.alpha)
+        info = {
+            "growth": growth,
+            "growth_c_allocated": growth_c_alloc,
+            "growth_p_allocated": growth_p_alloc,
+            "growth_c_used": growth_c_used,
+            "growth_p_used": growth_p_used,
+            "reproduction_c": reproduction_c,
+            "reproduction_p": reproduction_p,
+        }
+        return {
+            "growth": growth,
+            "reproduction_p": reproduction_p,
+            "c_pool": remaining_c_pool,
+            "p_pool": remaining_p_pool,
+            "reward": reward.squeeze(),
+            "info": info,
+        }
+
     def step_plant(self, key: jax.Array, state: State, action: jax.Array) -> dict:
-        """Step the plant dynamics based on the action allocation.
-
-        Currently, assumes action allocations are valid and sum to 1.0.
-        """
-
+        """Apply a valid Physical action to the plant's disposable pools."""
         operational = jnp.logical_and(
             self.plant_active, jnp.logical_not(state.plant_dead)
         )
-        action = jnp.where(operational, action, jnp.zeros_like(action))
-        active_biomass = jnp.where(operational, state.plant_biomass, 0.0)
-        growth_alloc = action[Actions.growth]
-        maintenance_alloc = action[Actions.maintenance]
-        reproduction_alloc = action[Actions.reproduction]
-
-        # Determine the growth based on essential resources.
-        growth_c_alloc = growth_alloc * state.plant_c_pool
-        growth_p_alloc = growth_alloc * state.plant_p_pool
-        growth = grow(
-            allocated_c=growth_c_alloc,
-            allocated_p=growth_p_alloc,
-            grow_c_cost=self.species.plant.gamma_c,
-            grow_p_cost=self.species.plant.gamma_p,
-            grow_type="essential",
+        return self._apply_allocation(
+            state.plant_biomass,
+            state.plant_c_pool,
+            state.plant_p_pool,
+            action,
+            self.species.plant,
+            operational,
+            biomass_cap=self.species.plant.biomass_cap,
         )
-        growth = jnp.minimum(
-            growth,
-            jnp.maximum(self.species.plant.biomass_cap - state.plant_biomass, 0.0),
-        )
-
-        # Determine real resources used for growth, e.g.,
-        # if using essential resources, the minimum of the two will determine actual growth.
-        growth_c_used = growth * self.species.plant.gamma_c
-        growth_p_used = growth * self.species.plant.gamma_p
-
-        # Determine required maintenance resources based on biomass and species traits.
-        required_maint_c, required_maint_p = plant_maintenance_demand(
-            active_biomass,
-            self.species.plant.kappa_c,
-            self.species.plant.kappa_p,
-            self.config.dt,
-        )
-
-        # Calculate allocated maintenance resources.
-        allocated_maint_c = maintenance_alloc * state.plant_c_pool
-        allocated_maint_p = maintenance_alloc * state.plant_p_pool
-
-        # Calculate actual maintenance resources used, which cannot exceed required amount.
-        # Over-allocated resources are returned to their pools.
-        maint_c_used = jnp.minimum(allocated_maint_c, required_maint_c)
-        maint_p_used = jnp.minimum(allocated_maint_p, required_maint_p)
-
-        # Calculate maintenance resource deficit, if any.
-        c_deficit = jnp.maximum(required_maint_c - allocated_maint_c, 0.0)
-        p_deficit = jnp.maximum(required_maint_p - allocated_maint_p, 0.0)
-
-        # Calculate the biomass deficit due to maintenance shortfall.
-        # Taking the maximum of carbon and phosphorus deficits converted to biomass.
-        maint_deficit_biomass = jnp.maximum(
-            c_deficit / self.species.plant.gamma_c,
-            p_deficit / self.species.plant.gamma_p,
-        )
-
-        # Calculate the resources allocated to reproduction.
-        reproduction_c = reproduction_alloc * state.plant_c_pool
-        reproduction_p = reproduction_alloc * state.plant_p_pool
-
-        # Calculate total resources used for maintenance, reproduction, and growth.
-        c_used = maint_c_used + reproduction_c + growth_c_used
-        p_used = maint_p_used + reproduction_p + growth_p_used
-
-        # Update the carbon and phosphorus pools after accounting for used resources.
-        c_pool = jnp.clip(state.plant_c_pool - c_used, 0.0, jnp.inf)
-        p_pool = jnp.clip(state.plant_p_pool - p_used, 0.0, jnp.inf)
-
-        # Get reward for reproduction based on Cobb-Douglas function of carbon and phosphorus.
-        # Scale reproduction C and P to be in terms of biomass for reward calculation.
-        reproduction_c_scaled = reproduction_c / self.species.plant.gamma_c
-        reproduction_p_scaled = reproduction_p / self.species.plant.gamma_p
-        reward = self._cobb_douglas(reproduction_c_scaled, reproduction_p_scaled, self.config.alpha)
-
-        info = {
-            "growth": growth,
-            "maint_c": required_maint_c,
-            "maint_p": required_maint_p,
-            "maint_c_used": maint_c_used,
-            "maint_p_used": maint_p_used,
-            "reproduction_c": reproduction_c,
-            "reproduction_p": reproduction_p,
-            "c_deficit": c_deficit,
-            "p_deficit": p_deficit,
-        }
-
-        return {
-            "growth": growth,
-            "maint_deficit_biomass": maint_deficit_biomass,
-            "reproduction_p": reproduction_p,
-            "c_pool": c_pool,
-            "p_pool": p_pool,
-            "reward": reward.squeeze(),
-            "info": info,
-        }
 
     def step_fungus(self, key: jax.Array, state: State, action: jax.Array) -> dict:
-        """Step the fungus dynamics based on the action allocation.
-
-        Currently, assumes action allocations are valid and sum to 1.0.
-        """
+        """Apply a valid Physical action to the fungus's disposable pools."""
         operational = jnp.logical_and(
             self.fungus_active, jnp.logical_not(state.fungus_dead)
         )
-        action = jnp.where(operational, action, jnp.zeros_like(action))
-        active_biomass = jnp.where(operational, state.fungus_biomass, 0.0)
-        growth_alloc = action[Actions.growth]
-        maint_alloc = action[Actions.maintenance]
-        reproduction_alloc = action[Actions.reproduction]
-
-        # Determine the growth based on essential resources.
-        growth_c_alloc = growth_alloc * state.fungus_c_pool
-        growth_p_alloc = growth_alloc * state.fungus_p_pool
-        growth = grow(
-            allocated_c=growth_c_alloc,
-            allocated_p=growth_p_alloc,
-            grow_c_cost=self.species.fungus.gamma_c,
-            grow_p_cost=self.species.fungus.gamma_p,
-            grow_type="essential",
+        return self._apply_allocation(
+            state.fungus_biomass,
+            state.fungus_c_pool,
+            state.fungus_p_pool,
+            action,
+            self.species.fungus,
+            operational,
         )
-
-        # Determine real resources used for growth, e.g.,
-        # if using essential resources, the minimum of the two will determine actual growth.
-        growth_c_used = growth * self.species.fungus.gamma_c
-        growth_p_used = growth * self.species.fungus.gamma_p
-
-        # Determine required maintenance resources based on biomass and species traits.
-        required_maint_c, required_maint_p = fungal_maintenance_demand(
-            active_biomass,
-            self.species.fungus.kappa_c,
-            self.species.fungus.kappa_p,
-            self.config.dt,
-        )
-
-        # Calculate allocated maintenance resources.
-        allocated_maint_c = maint_alloc * state.fungus_c_pool
-        allocated_maint_p = maint_alloc * state.fungus_p_pool
-
-        # Calculate actual maintenance resources used, which cannot exceed required amount.
-        # Over-allocated resources are returned to their pools.
-        maint_c_used = jnp.minimum(allocated_maint_c, required_maint_c)
-        maint_p_used = jnp.minimum(allocated_maint_p, required_maint_p)
-
-        # Calculate maintenance resource deficit, if any.
-        c_deficit = jnp.maximum(required_maint_c - allocated_maint_c, 0.0)
-        p_deficit = jnp.maximum(required_maint_p - allocated_maint_p, 0.0)
-
-        # Calculate the biomass deficit due to maintenance shortfall.
-        # Taking the maximum of carbon and phosphorus deficits converted to biomass.
-        maint_deficit_biomass = jnp.maximum(
-            c_deficit / self.species.fungus.gamma_c,
-            p_deficit / self.species.fungus.gamma_p,
-        )
-
-        # Calculate the resources allocated to reproduction.
-        reproduction_c = reproduction_alloc * state.fungus_c_pool
-        reproduction_p = reproduction_alloc * state.fungus_p_pool
-
-        # Calculate total resources used for maintenance, reproduction, and growth.
-        c_used = maint_c_used + reproduction_c + growth_c_used
-        p_used = maint_p_used + reproduction_p + growth_p_used
-
-        # Update the carbon and phosphorus pools after accounting for used resources.
-        c_pool = jnp.clip(state.fungus_c_pool - c_used, 0.0, jnp.inf)
-        p_pool = jnp.clip(state.fungus_p_pool - p_used, 0.0, jnp.inf)
-
-        # Get reward for reproduction based on Cobb-Douglas function of carbon and phosphorus.
-        # Scale reproduction C and P to be in terms of biomass for reward calculation.
-        reproductive_c = reproduction_c / self.species.fungus.gamma_c
-        reproductive_p = reproduction_p / self.species.fungus.gamma_p
-        reward = self._cobb_douglas(reproductive_c, reproductive_p, self.config.alpha)
-
-        info = {
-            "growth": growth,
-            "maint_c": required_maint_c,
-            "maint_p": required_maint_p,
-            "maint_c_used": maint_c_used,
-            "maint_p_used": maint_p_used,
-            "reproduction_c": reproduction_c,
-            "reproduction_p": reproduction_p,
-            "c_deficit": c_deficit,
-            "p_deficit": p_deficit,
-        }
-
-        return {
-            "growth": growth,
-            "maint_deficit_biomass": maint_deficit_biomass,
-            "reproduction_p": reproduction_p,
-            "c_pool": c_pool,
-            "p_pool": p_pool,
-            "reward": reward.squeeze(),
-            "info": info,
-        }
 
     @staticmethod
     def _validate_soil_config(config: EnvConfig) -> None:

--- a/mycormarl/mycormarl/environments/base_mycor.py
+++ b/mycormarl/mycormarl/environments/base_mycor.py
@@ -31,6 +31,7 @@ from mycormarl.soil import (
 from mycormarl.plant import photosynthesise
 from mycormarl.observations import actor_observation
 from mycormarl.state import State
+from mycormarl.transition import Transition
 
 
 # TODO: consider more complex allocation strategies based on past allocations.
@@ -500,6 +501,40 @@ class BaseMycorMarl(MultiAgentEnv):
             FUNGUS: fungus_dead.squeeze(),
             "__all__": done,
         }
+
+        def completed_transition(
+            requested_action,
+            operational_at_start,
+            operational_at_end,
+            final_observation,
+        ):
+            realised_action = jnp.concatenate(
+                [
+                    jnp.atleast_1d(
+                        jnp.where(
+                            trading_enabled,
+                            requested_action[Actions.trade],
+                            0.0,
+                        )
+                    ),
+                    jnp.where(
+                        operational_at_end,
+                        requested_action[Actions.growth :],
+                        0.0,
+                    ),
+                ]
+            )
+            return Transition(
+                requested_action=requested_action,
+                realised_action=realised_action,
+                operational_at_start=operational_at_start.squeeze(),
+                operational_at_end=operational_at_end.squeeze(),
+                allocation_executed=operational_at_end.squeeze(),
+                trade_executed=trading_enabled.squeeze(),
+                truncated=state.step >= self.max_episode_steps,
+                final_observation=final_observation,
+            )
+
         infos = {
             PLANT: {
                 **plant_step["info"],
@@ -522,6 +557,20 @@ class BaseMycorMarl(MultiAgentEnv):
                 "trade_out": fungus_p_trade_out,
                 "trade_in": plant_c_trade_out,
                 "trade_cancelled": trade_cancelled,
+            },
+            "transitions": {
+                PLANT: completed_transition(
+                    actions[PLANT],
+                    plant_operational_at_start,
+                    plant_operational_at_end,
+                    obs[PLANT],
+                ),
+                FUNGUS: completed_transition(
+                    actions[FUNGUS],
+                    fungus_operational_at_start,
+                    fungus_operational_at_end,
+                    obs[FUNGUS],
+                ),
             },
         }
 

--- a/mycormarl/mycormarl/environments/base_mycor.py
+++ b/mycormarl/mycormarl/environments/base_mycor.py
@@ -32,7 +32,7 @@ from mycormarl.soil import (
 )
 from mycormarl.plant import photosynthesise
 from mycormarl.actions import constrain_allocation
-from mycormarl.observations import _normalize_if
+from mycormarl.observations import actor_observation
 from mycormarl.state import State
 
 
@@ -120,15 +120,15 @@ class BaseMycorMarl(MultiAgentEnv):
             self.z_edges.shape[0] - 1,
         )
 
-        obs_dim = 4 # [biomass, carbon_pool, phosphorus_pool, received_trades] normalised
+        obs_dim = 5
 
         self.action_set = jnp.array(
             [Actions.trade, Actions.growth, Actions.maintenance, Actions.reproduction]
         )
 
         self.observation_spaces = {
-            PLANT: Box(low=-jnp.inf, high=jnp.inf, shape=(obs_dim,), dtype=jnp.float32),
-            FUNGUS: Box(low=-jnp.inf, high=jnp.inf, shape=(obs_dim,), dtype=jnp.float32),
+            PLANT: Box(low=0.0, high=1.0, shape=(obs_dim,), dtype=jnp.float32),
+            FUNGUS: Box(low=0.0, high=1.0, shape=(obs_dim,), dtype=jnp.float32),
         }
         # Four continuous allocations: trade, growth, maintenance, reproduction.
         self.action_spaces = {
@@ -147,36 +147,61 @@ class BaseMycorMarl(MultiAgentEnv):
     def agent_classes(self) -> dict:
         return {PLANT: [PLANT], FUNGUS: [FUNGUS]}
 
-    def _get_obs(
-        self,
-        state: State,
-        last_trade: Optional[Dict[str, chex.Array]] = None,
-    ) -> Dict[str, chex.Array]:
+    def get_obs(self, state: State) -> Dict[str, chex.Array]:
+        """Reconstruct bounded actor observations entirely from environment state."""
+        # Calculate reference biomasses for normalization.
+        # Use 0.5 * maximum so that normed obs is also half-maximum.
+        plant_biomass_reference = 0.5 * self.species.plant.biomass_cap
 
-        if last_trade is None:
-            plant_trade_obs = jnp.zeros_like(state.plant_p_pool)
-            fungus_trade_obs = jnp.zeros_like(state.fungus_c_pool)
-        else:
-            plant_trade_obs = last_trade[PLANT]
-            fungus_trade_obs = last_trade[FUNGUS]
+        # Calculate ref biomass based on maximum radius possible constrained by
+        # grid boundaries.
+        fungus_biomass_reference = (
+            0.5
+            * fungus.fungal_biomass_for_colony_radius(
+                self.config.soil_radius_cm,
+                self.species.fungus,
+            )
+        )
 
-        plant_obs = jnp.concatenate([
-            _normalize_if(self.config.norm_obs, state.plant_biomass, self.species.plant.biomass_cap),
-            _normalize_if(self.config.norm_obs, state.plant_c_pool, state.plant_biomass),
-            _normalize_if(self.config.norm_obs, state.plant_p_pool, state.plant_biomass),
-            _normalize_if(self.config.norm_obs, plant_trade_obs, state.plant_p_pool),
-        ])
-
-        fungus_obs = jnp.concatenate([
-            _normalize_if(self.config.norm_obs, state.fungus_biomass, self.species.plant.biomass_cap),
-            _normalize_if(self.config.norm_obs, state.fungus_c_pool, state.fungus_biomass),
-            _normalize_if(self.config.norm_obs, state.fungus_p_pool, state.fungus_biomass),
-            _normalize_if(self.config.norm_obs, fungus_trade_obs, state.fungus_c_pool),
-        ])
+        association = (
+            jnp.asarray(self.plant_active and self.fungus_active)
+            & ~state.plant_dead
+            & ~state.fungus_dead
+        )
 
         return {
-            PLANT: plant_obs.astype(jnp.float32),
-            FUNGUS: fungus_obs.astype(jnp.float32),
+            PLANT: actor_observation(
+                biomass=state.plant_biomass,
+                biomass_reference=plant_biomass_reference,
+                c_pool=state.plant_c_pool,
+                gamma_c=self.species.plant.gamma_c,
+                p_pool=state.plant_p_pool,
+                gamma_p=self.species.plant.gamma_p,
+                last_received=state.plant_last_p_received,
+                maintenance_need=(
+                    self.species.plant.kappa_p
+                    * state.plant_biomass
+                    * self.config.dt
+                ),
+                association=association,
+                operational=~state.plant_dead,
+            ),
+            FUNGUS: actor_observation(
+                biomass=state.fungus_biomass,
+                biomass_reference=fungus_biomass_reference,
+                c_pool=state.fungus_c_pool,
+                gamma_c=self.species.fungus.gamma_c,
+                p_pool=state.fungus_p_pool,
+                gamma_p=self.species.fungus.gamma_p,
+                last_received=state.fungus_last_c_received,
+                maintenance_need=(
+                    self.species.fungus.kappa_c
+                    * state.fungus_biomass
+                    * self.config.dt
+                ),
+                association=association,
+                operational=~state.fungus_dead,
+            ),
         }
 
     def _initial_state(self) -> State:
@@ -235,6 +260,8 @@ class BaseMycorMarl(MultiAgentEnv):
             fungus_p_pool=jnp.array([
                 self.species.fungus.initial_p_pool if self.fungus_active else 0.0
             ]),
+            plant_last_p_received=jnp.array([0.0]),
+            fungus_last_c_received=jnp.array([0.0]),
             soil_labile_p=soil_labile_p,
             root_length_density=root_length_density,
             hyphae_length_density=hyphae_length_density,
@@ -250,7 +277,7 @@ class BaseMycorMarl(MultiAgentEnv):
     def reset(self, key: chex.PRNGKey) -> Tuple[Dict[str, chex.Array], State]:
         state = self._initial_state()
 
-        obs = self._get_obs(state)
+        obs = self.get_obs(state)
         return obs, state
 
     def step_env(
@@ -355,6 +382,16 @@ class BaseMycorMarl(MultiAgentEnv):
             plant_p_pool=plant_step["p_pool"] + fungus_p_trade_out,
             fungus_c_pool=fungus_step["c_pool"] + plant_c_trade_out,
             fungus_p_pool=jnp.clip(fungus_step["p_pool"] - fungus_p_trade_out, 0.0, jnp.inf),
+            plant_last_p_received=jnp.where(
+                jnp.logical_and(self.plant_active, jnp.logical_not(plant_dead)),
+                fungus_p_trade_out,
+                0.0,
+            ),
+            fungus_last_c_received=jnp.where(
+                jnp.logical_and(self.fungus_active, jnp.logical_not(fungus_dead)),
+                plant_c_trade_out,
+                0.0,
+            ),
             cumulative_plant_p_mortality_loss_mg=(
                 state.cumulative_plant_p_mortality_loss_mg
                 + plant_mortality_biomass * self.species.plant.gamma_p
@@ -407,13 +444,7 @@ class BaseMycorMarl(MultiAgentEnv):
         done = self.is_terminal(state)
         state = state.replace(terminal=done)
 
-        obs = self._get_obs(
-            state,
-            last_trade={
-                PLANT: fungus_p_trade_out,
-                FUNGUS: plant_c_trade_out,
-            },
-        )
+        obs = self.get_obs(state)
 
         rewards = {
             PLANT: plant_step["reward"],
@@ -698,8 +729,6 @@ class BaseMycorMarl(MultiAgentEnv):
             raise ValueError(
                 "consumer_mode must be 'mixed', 'plant-only', or 'fungus-only'"
             )
-        if not isinstance(config.norm_obs, bool):
-            raise ValueError("norm_obs must be a boolean")
         if not math.isfinite(config.alpha) or not 0.0 <= config.alpha <= 1.0:
             raise ValueError("alpha must be finite and within [0, 1]")
         if (

--- a/mycormarl/mycormarl/fungus/__init__.py
+++ b/mycormarl/mycormarl/fungus/__init__.py
@@ -6,6 +6,9 @@ from .mycelium import (
     axisymmetric_hemisphere_density,
     colony_radius_from_length_axisymmetric,
     density_field_from_biomass,
+    fungal_biomass_for_colony_radius,
+    fungal_biomass_from_hyphal_length,
+    hyphal_length_for_colony_radius_axisymmetric,
     hyphal_length_from_fungal_biomass,
 )
 
@@ -17,6 +20,9 @@ __all__ = [
     "colony_radius_from_length_axisymmetric",
     "fungal_maintenance_demand",
     "density_field_from_biomass",
+    "fungal_biomass_for_colony_radius",
+    "fungal_biomass_from_hyphal_length",
+    "hyphal_length_for_colony_radius_axisymmetric",
     "hyphal_length_from_fungal_biomass",
     "validate_fungus_growth_geometry_traits",
 ]

--- a/mycormarl/mycormarl/fungus/mycelium.py
+++ b/mycormarl/mycormarl/fungus/mycelium.py
@@ -25,6 +25,55 @@ def hyphal_length_from_fungal_biomass(
         / (tissue_carbon_density_g_c_cm3 * cross_section_cm2)
     )
 
+
+def fungal_biomass_from_hyphal_length(
+        total_length_cm: chex.Array,
+        gamma_c_g_c_per_g: float,
+        tissue_carbon_density_g_c_cm3: float,
+        hyphal_radius_cm: float,
+    ) -> chex.Array:
+    """Convert cylindrical external-hyphal length to fungal dry biomass."""
+    total_length_cm = jnp.maximum(jnp.asarray(total_length_cm), 0.0)
+    cross_section_cm2 = jnp.pi * hyphal_radius_cm ** 2
+    structural_carbon_g = (
+        total_length_cm
+        * cross_section_cm2
+        * tissue_carbon_density_g_c_cm3
+    )
+    return structural_carbon_g / gamma_c_g_c_per_g
+
+
+def hyphal_length_for_colony_radius_axisymmetric(
+        colony_radius_cm: chex.Array,
+        saturation_density: float,
+    ) -> chex.Array:
+    """Return the length in a saturated hemisphere of the requested radius."""
+    colony_radius_cm = jnp.maximum(jnp.asarray(colony_radius_cm), 0.0)
+    return (
+        (2.0 / 3.0)
+        * jnp.pi
+        * colony_radius_cm ** 3
+        * saturation_density
+    )
+
+
+def fungal_biomass_for_colony_radius(
+        colony_radius_cm: chex.Array,
+        traits,
+    ) -> chex.Array:
+    """Invert the fungal biomass-to-saturated-hemisphere radius pipeline."""
+    total_length_cm = hyphal_length_for_colony_radius_axisymmetric(
+        colony_radius_cm,
+        traits.saturation_density,
+    )
+    return fungal_biomass_from_hyphal_length(
+        total_length_cm,
+        traits.gamma_c,
+        traits.hyphal_tissue_carbon_density,
+        traits.hyphal_radius,
+    )
+
+
 def colony_radius_from_length_axisymmetric(total_length, saturation_density):
     """Return the radius of a saturated hemisphere containing total length."""
     return jnp.cbrt((3 * total_length) / (2 * jnp.pi * saturation_density))

--- a/mycormarl/mycormarl/observations.py
+++ b/mycormarl/mycormarl/observations.py
@@ -2,8 +2,41 @@
 import chex
 import jax.numpy as jnp
 
-def _safe_div(numer: chex.Array, denom: chex.Array, eps: float = 1e-8) -> chex.Array:
-    return numer / jnp.maximum(denom, eps)
 
-def _normalize_if(norm: bool, x: chex.Array, scale: chex.Array) -> chex.Array:
-    return _safe_div(x, scale) if norm else x
+OBS_EPS = 1e-8
+
+
+def bounded_saturating_ratio(
+    amount: chex.Array, reference: chex.Array
+) -> chex.Array:
+    """Map a non-negative amount and reference to a finite ratio in [0, 1]."""
+    amount = jnp.maximum(amount, 0.0)
+    reference = jnp.maximum(reference, 0.0)
+    ratio = amount / jnp.maximum(amount + reference, OBS_EPS)
+    return jnp.clip(jnp.nan_to_num(ratio, nan=0.0, posinf=1.0), 0.0, 1.0)
+
+
+def actor_observation(
+    *,
+    biomass: chex.Array,
+    biomass_reference: chex.Array,
+    c_pool: chex.Array,
+    gamma_c: float,
+    p_pool: chex.Array,
+    gamma_p: float,
+    last_received: chex.Array,
+    maintenance_need: chex.Array,
+    association: chex.Array,
+    operational: chex.Array,
+) -> chex.Array:
+    """Build one actor's ordered five-feature observation."""
+    observation = jnp.concatenate(
+        [
+            bounded_saturating_ratio(biomass, biomass_reference),
+            bounded_saturating_ratio(c_pool, gamma_c * biomass),
+            bounded_saturating_ratio(p_pool, gamma_p * biomass),
+            bounded_saturating_ratio(last_received, maintenance_need),
+            association.astype(jnp.float32),
+        ]
+    )
+    return jnp.where(operational, observation, 0.0).astype(jnp.float32)

--- a/mycormarl/mycormarl/params.py
+++ b/mycormarl/mycormarl/params.py
@@ -43,4 +43,3 @@ class EnvConfig:
     uptake_transition_exponent: float = 2.0
     theta_water: float = 0.3
     alpha: float = 0.5
-    norm_obs: bool = True

--- a/mycormarl/mycormarl/phosphate_examples.py
+++ b/mycormarl/mycormarl/phosphate_examples.py
@@ -29,7 +29,6 @@ def example_config() -> EnvConfig:
         depth_interval_cm=0.1,
         topsoil_depth_cm=0.2,
         initial_solution_p_um=1.0,
-        norm_obs=False,
     )
 
 

--- a/mycormarl/mycormarl/state.py
+++ b/mycormarl/mycormarl/state.py
@@ -10,6 +10,8 @@ class State:
 
     Arrays are stored explicitly so the model stays JAX-friendly and easy to
     extend.
+
+    Cumulative P loss fields are stored to ensure P conservation.
     """
 
     plant_biomass: chex.Array # shape (n_plant_agents,)
@@ -27,6 +29,8 @@ class State:
     hyphae_length_density: chex.Array  # cm cm^-3; shape (n_r, n_z)
     cumulative_plant_p_mortality_loss_mg: chex.Array  # shape (n_plant_agents,)
     cumulative_fungus_p_mortality_loss_mg: chex.Array  # shape (n_fungus_agents,)
+    cumulative_plant_p_maintenance_loss_mg: chex.Array  # shape (n_plant_agents,)
+    cumulative_fungus_p_maintenance_loss_mg: chex.Array  # shape (n_fungus_agents,)
     cumulative_plant_p_reproduction_export_mg: chex.Array  # shape (n_plant_agents,)
     cumulative_fungus_p_reproduction_export_mg: chex.Array  # shape (n_fungus_agents,)
     plant_dead: chex.Array # shape (n_plant_agents,)

--- a/mycormarl/mycormarl/state.py
+++ b/mycormarl/mycormarl/state.py
@@ -20,6 +20,8 @@ class State:
     plant_p_pool: chex.Array # shape (n_plant_agents,)
     fungus_c_pool: chex.Array # shape (n_fungus_agents,)
     fungus_p_pool: chex.Array # shape (n_fungus_agents,)
+    plant_last_p_received: chex.Array  # shape (n_plant_agents,)
+    fungus_last_c_received: chex.Array  # shape (n_fungus_agents,)
     soil_labile_p: chex.Array  # µmol P per cell; shape (n_r, n_z)
     root_length_density: chex.Array  # cm cm^-3; shape (n_r, n_z)
     hyphae_length_density: chex.Array  # cm cm^-3; shape (n_r, n_z)

--- a/mycormarl/mycormarl/transition.py
+++ b/mycormarl/mycormarl/transition.py
@@ -1,0 +1,16 @@
+import chex
+from flax import struct
+
+
+@struct.dataclass
+class Transition:
+    """Algorithm-independent facts for one agent's completed environment step."""
+
+    requested_action: chex.Array
+    realised_action: chex.Array
+    operational_at_start: chex.Array
+    operational_at_end: chex.Array
+    allocation_executed: chex.Array
+    trade_executed: chex.Array
+    truncated: chex.Array
+    final_observation: chex.Array

--- a/scripts/geometry_growth_video.py
+++ b/scripts/geometry_growth_video.py
@@ -28,7 +28,10 @@ os.environ.setdefault(
 import chex
 import jax.numpy as jnp
 
-from mycormarl.fungus.mycelium import axisymmetric_density_from_biomass
+from mycormarl.fungus.mycelium import (
+    axisymmetric_density_from_biomass,
+    fungal_biomass_for_colony_radius,
+)
 from mycormarl.fungus.traits import FungusTraits
 from mycormarl.plant.roots import axisymmetric_stacked_disc_root_density
 from mycormarl.plant.roots import root_disc_radii_from_biomass
@@ -57,22 +60,6 @@ def growth_radii_from_grid(
             f"to {MAX_VIDEO_FRAMES:,} frames."
         )
     return r_edges[1:]
-
-
-def fungal_biomass_for_colony_radius(
-        colony_radius_cm: float,
-        traits: FungusTraits,
-    ) -> chex.Array:
-    """Invert the fungal geometry conversion for a target colony radius."""
-    total_length_cm = (
-        traits.saturation_density
-        * (2.0 / 3.0)
-        * jnp.pi
-        * colony_radius_cm**3
-    )
-    tissue_volume_cm3 = total_length_cm * jnp.pi * traits.hyphal_radius**2
-    structural_carbon_g = tissue_volume_cm3 * traits.hyphal_tissue_carbon_density
-    return structural_carbon_g / traits.gamma_c
 
 
 def root_biomass_for_max_disc_radius(

--- a/scripts/phosphate_qualification.py
+++ b/scripts/phosphate_qualification.py
@@ -81,7 +81,6 @@ def qualification_config(
         initial_solution_p_um=concentration_um,
         uptake_reference_time_days=reference_time_days,
         uptake_transition_exponent=exponent,
-        norm_obs=False,
     )
 
 
@@ -533,7 +532,7 @@ def run_studies(include_target_benchmark: bool) -> dict:
     if include_target_benchmark:
         annual_steps = annual_runtime_projection(selected_dt, 0.0)["steps_per_year"]
         target_benchmark = benchmark_environment(
-            EnvConfig(dt=selected_dt, max_steps=annual_steps, norm_obs=False),
+            EnvConfig(dt=selected_dt, max_steps=annual_steps),
             repeats=20,
         )
     return {

--- a/scripts/phosphate_qualification.py
+++ b/scripts/phosphate_qualification.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 
+from mycormarl.actions import physical_action
 from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
 from mycormarl.fungus.traits import FungusTraits
 from mycormarl.params import EnvConfig, SpeciesParams
@@ -266,6 +267,8 @@ def run_coupled_scenario(interval_cm: float, dt_days: float) -> dict:
             + float(
                 current_state.cumulative_plant_p_mortality_loss_mg[0]
                 + current_state.cumulative_fungus_p_mortality_loss_mg[0]
+                + current_state.cumulative_plant_p_maintenance_loss_mg[0]
+                + current_state.cumulative_fungus_p_maintenance_loss_mg[0]
                 + current_state.cumulative_plant_p_reproduction_export_mg[0]
                 + current_state.cumulative_fungus_p_reproduction_export_mg[0]
             )
@@ -273,8 +276,8 @@ def run_coupled_scenario(interval_cm: float, dt_days: float) -> dict:
 
     initial_extended_p_mg = extended_p_mg(state)
     actions = {
-        PLANT: jnp.array([0.25, 0.75, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.25, 0.75, 0.0, 0.0]),
+        PLANT: physical_action(0.25, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.25, 1.0, 0.0, 0.0),
     }
     for step_index in range(round(HORIZON_DAYS / dt_days)):
         plant_p_before = float(state.plant_p_pool[0])
@@ -339,6 +342,8 @@ def run_coupled_scenario(interval_cm: float, dt_days: float) -> dict:
         "fungus_p_pool_mg": float(state.fungus_p_pool[0]),
         "plant_mortality_loss_mg": float(state.cumulative_plant_p_mortality_loss_mg[0]),
         "fungus_mortality_loss_mg": float(state.cumulative_fungus_p_mortality_loss_mg[0]),
+        "plant_maintenance_loss_mg": float(state.cumulative_plant_p_maintenance_loss_mg[0]),
+        "fungus_maintenance_loss_mg": float(state.cumulative_fungus_p_maintenance_loss_mg[0]),
         "plant_reproduction_export_mg": float(state.cumulative_plant_p_reproduction_export_mg[0]),
         "fungus_reproduction_export_mg": float(state.cumulative_fungus_p_reproduction_export_mg[0]),
         "initial_extended_p_mg": initial_extended_p_mg,
@@ -400,8 +405,8 @@ def benchmark_environment(config: EnvConfig, repeats: int = 20) -> dict:
     soil_projection = annual_runtime_projection(config.dt, warmed_seconds)
     _, full_state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.25, 0.75, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.25, 0.75, 0.0, 0.0]),
+        PLANT: physical_action(0.25, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.25, 1.0, 0.0, 0.0),
     }
     key = jax.random.PRNGKey(1)
     compiled_full_step = jax.jit(
@@ -668,7 +673,7 @@ def render_markdown(results: dict) -> str:
         "- No scientific matrix row was inventory-capped. Fixed-soil outputs changed by less than 0.5% across the timestep candidates, but endpoint coupled free-P pools changed by approximately 98–102%; none of the coarser timestep candidates passed the 5% gate.",
         "- 0.025 day is the finest tested timestep and was selected as the fallback. Because it has no finer reference, this result does not demonstrate timestep convergence; a finer follow-up study or a revised scientifically justified endpoint metric is required.",
         "- Reduced-domain convergence retains a topsoil diffusion front but cannot reproduce every full-domain spatial scale.",
-        "- Coupled actions are fixed at `[trade=0.25, growth=0.75, maintenance=0, reproduction=0]`; maintenance costs are disabled only in this qualification fixture so the unresolved maintenance-P fate cannot contaminate balance interpretation.",
+        "- Coupled Physical actions are fixed at `[trade=0.25, growth=1, reproduction=0, reserve=0]`; automatic maintenance costs are disabled in this fixture to isolate timestep sensitivity in growth and uptake.",
         "- Annual runtime is projected from both warmed soil-only and deterministic full-environment steps. MARL training, learned-policy inference, output, and accelerator transfer costs are excluded.",
         "- The complete machine-readable tables and exact platform metadata are in `phosphate-numerical-qualification.json`.",
         "",

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,99 +1,46 @@
 import jax
 import jax.numpy as jnp
-import pytest
 
-from mycormarl.actions import _allocation_from_action, _check_action, constrain_allocation
+from mycormarl.actions import physical_action
 
 
-def assert_simplex(action, n_parts=4):
-    """Assert that an action vector is a valid allocation on the simplex."""
-    assert isinstance(action, jax.Array)
-    assert action.shape == (n_parts,)
+def test_physical_action_bounds_trade_independently_of_biological_allocation():
+    action = physical_action(
+        trade=0.75,
+        growth=2.0,
+        reproduction=1.0,
+        reserve=1.0,
+    )
+
+    assert action.dtype == jnp.float32
+    assert jnp.allclose(action, jnp.array([0.75, 0.5, 0.25, 0.25]))
+
+
+def test_physical_action_replaces_non_finite_inputs_with_a_valid_fallback():
+    action = physical_action(
+        trade=jnp.nan,
+        growth=jnp.nan,
+        reproduction=jnp.inf,
+        reserve=-jnp.inf,
+    )
+
     assert jnp.all(jnp.isfinite(action))
-    assert jnp.all(action >= 0.0)
-    assert jnp.all(action <= 1.0)
-    assert jnp.sum(action) == pytest.approx(1.0)
+    assert jnp.allclose(action, jnp.array([0.0, 1 / 3, 1 / 3, 1 / 3]))
 
 
-def test_check_action_clips_to_unit_interval_without_normalising():
-    checked = _check_action(jnp.array([-1.0, 0.25, 2.0, 0.5]))
+def test_physical_action_is_jittable_and_vectorises_over_callers():
+    make_actions = jax.jit(
+        jax.vmap(physical_action, in_axes=(0, 0, 0, 0))
+    )
 
-    assert checked.shape == (4,)
-    assert jnp.allclose(checked, jnp.array([0.0, 0.25, 1.0, 0.5]))
+    actions = make_actions(
+        jnp.array([-1.0, 0.25, 2.0]),
+        jnp.array([1.0, 0.0, 1.0]),
+        jnp.array([0.0, 1.0, 1.0]),
+        jnp.array([0.0, 0.0, 2.0]),
+    )
 
-
-def test_check_action_replaces_non_finite_values_with_zero():
-    checked = _check_action(jnp.array([jnp.nan, jnp.inf, -jnp.inf, 0.5]))
-
-    assert jnp.allclose(checked, jnp.array([0.0, 0.0, 0.0, 0.5]))
-
-
-def test_check_action_raises_for_wrong_final_dimension():
-    with pytest.raises(ValueError):
-        _check_action(jnp.array([0.25, 0.25, 0.25]), n_parts=4)
-
-
-def test_allocation_from_action_preserves_valid_normalized_action():
-    action = jnp.array([0.1, 0.2, 0.3, 0.4])
-
-    allocation = _allocation_from_action(action)
-
-    assert_simplex(allocation)
-    assert jnp.allclose(allocation, action)
-
-
-def test_constrain_allocation_preserves_valid_normalized_action():
-    action = jnp.array([0.4, 0.3, 0.2, 0.1])
-
-    allocation = constrain_allocation(action)
-
-    assert_simplex(allocation)
-    assert jnp.allclose(allocation, action)
-
-
-@pytest.mark.parametrize(
-    ("action", "expected"),
-    [
-        (jnp.array([2.0, 1.0, 1.0, 0.0]), jnp.array([1 / 3, 1 / 3, 1 / 3, 0.0])),
-        (jnp.array([-1.0, 0.5, 0.5, 0.0]), jnp.array([0.0, 0.5, 0.5, 0.0])),
-        (jnp.array([0.0, 2.0, 0.0, 0.0]), jnp.array([0.0, 1.0, 0.0, 0.0])),
-        (jnp.array([jnp.nan, 0.2, 0.3, 0.5]), jnp.array([0.0, 0.2, 0.3, 0.5])),
-        (jnp.array([jnp.inf, 0.0, 1.0, 1.0]), jnp.array([0.0, 0.0, 0.5, 0.5])),
-    ],
-)
-def test_constrain_allocation_clips_sanitizes_and_renormalizes(action, expected):
-    allocation = constrain_allocation(action)
-
-    assert_simplex(allocation)
-    assert jnp.allclose(allocation, expected)
-
-
-@pytest.mark.parametrize(
-    "action",
-    [
-        jnp.array([0.0, 0.0, 0.0, 0.0]),
-        jnp.array([-1.0, -2.0, -3.0, -4.0]),
-        jnp.array([jnp.nan, jnp.inf, -jnp.inf, jnp.nan]),
-    ],
-)
-def test_constrain_allocation_returns_uniform_when_no_positive_weight_remains(action):
-    allocation = constrain_allocation(action)
-
-    assert_simplex(allocation)
-    assert jnp.allclose(allocation, jnp.ones(4) / 4)
-
-
-def test_constrain_allocation_accepts_configurable_action_length():
-    allocation = constrain_allocation(jnp.array([2.0, 1.0, 0.0]), n_parts=3)
-
-    assert_simplex(allocation, n_parts=3)
-    assert jnp.allclose(allocation, jnp.array([0.5, 0.5, 0.0]))
-
-
-def test_constrain_allocation_is_jittable():
-    action = jnp.array([-1.0, 0.0, 2.0, jnp.nan])
-
-    allocation = jax.jit(constrain_allocation)(action)
-
-    assert_simplex(allocation)
-    assert jnp.allclose(allocation, jnp.array([0.0, 0.0, 1.0, 0.0]))
+    assert actions.shape == (3, 4)
+    assert jnp.all(jnp.isfinite(actions))
+    assert jnp.all((actions[:, 0] >= 0.0) & (actions[:, 0] <= 1.0))
+    assert jnp.allclose(jnp.sum(actions[:, 1:], axis=-1), 1.0)

--- a/tests/test_actor_observations.py
+++ b/tests/test_actor_observations.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from mycormarl.actions import constrain_allocation
+from mycormarl.actions import physical_action
 from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
 from mycormarl.fungus.traits import FungusTraits
 from mycormarl.params import EnvConfig, SpeciesParams
@@ -142,8 +142,8 @@ def test_step_stores_realised_received_trade_before_reconstructing_observations(
     env = _environment()
     _, state = env.reset(jax.random.PRNGKey(0))
     trade_everything = {
-        PLANT: constrain_allocation(jnp.array([1.0, 0.0, 0.0, 0.0])),
-        FUNGUS: constrain_allocation(jnp.array([1.0, 0.0, 0.0, 0.0])),
+        PLANT: physical_action(1.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(1.0, 0.0, 0.0, 1.0),
     }
 
     observations, next_state, _, _, _ = env.step_env(
@@ -232,8 +232,8 @@ def test_no_trade_transition_clears_previous_received_trade_memory():
         fungus_last_c_received=jnp.array([4.0]),
     )
     no_trade = {
-        PLANT: constrain_allocation(jnp.array([0.0, 1.0, 0.0, 0.0])),
-        FUNGUS: constrain_allocation(jnp.array([0.0, 1.0, 0.0, 0.0])),
+        PLANT: physical_action(0.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.0, 1.0, 0.0, 0.0),
     }
 
     observations, next_state, _, _, _ = env.step_env(

--- a/tests/test_actor_observations.py
+++ b/tests/test_actor_observations.py
@@ -1,0 +1,258 @@
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from mycormarl.actions import constrain_allocation
+from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
+from mycormarl.fungus.traits import FungusTraits
+from mycormarl.params import EnvConfig, SpeciesParams
+from mycormarl.plant.traits import PlantTraits
+
+
+def _environment(
+    *,
+    config: EnvConfig | None = None,
+    plant: PlantTraits | None = None,
+    fungus: FungusTraits | None = None,
+) -> BaseMycorMarl:
+    return BaseMycorMarl(
+        config
+        or EnvConfig(
+            dt=1.0,
+            max_steps=2,
+            soil_radius_cm=1.0,
+            soil_depth_cm=1.0,
+            radial_interval_cm=0.5,
+            depth_interval_cm=0.5,
+            topsoil_depth_cm=0.5,
+            initial_solution_p_um=0.0,
+        ),
+        SpeciesParams(
+            plant=plant
+            or PlantTraits(
+                initial_biomass=10.0,
+                initial_c_pool=20.0,
+                initial_p_pool=10.0,
+                biomass_cap=100.0,
+                kappa_c=0.0,
+                kappa_p=0.0,
+            ),
+            fungus=fungus
+            or FungusTraits(
+                initial_biomass=8.0,
+                initial_c_pool=12.0,
+                initial_p_pool=16.0,
+                kappa_c=0.0,
+                kappa_p=0.0,
+            ),
+        ),
+    )
+
+
+def test_reset_returns_stable_bounded_actor_observation_contract():
+    env = _environment()
+
+    observations, _ = env.reset(jax.random.PRNGKey(0))
+
+    for agent in (PLANT, FUNGUS):
+        observation = observations[agent]
+        space = env.observation_spaces[agent]
+        assert observation.shape == space.shape == (5,)
+        assert observation.dtype == space.dtype == jnp.float32
+        assert jnp.all(space.low == 0.0)
+        assert jnp.all(space.high == 1.0)
+        assert jnp.all(jnp.isfinite(observation))
+        assert jnp.all((observation >= 0.0) & (observation <= 1.0))
+        assert observation[3] == 0.0
+        assert observation[4] == 1.0
+
+
+def test_state_observations_use_agreed_feature_equations_and_order():
+    """The synthetic fungal traits make radial-fill biomass 1 g."""
+    env = _environment(
+        plant=PlantTraits(
+            initial_biomass=50.0,
+            initial_c_pool=100.0,
+            initial_p_pool=150.0,
+            biomass_cap=100.0,
+            gamma_c=2.0,
+            gamma_p=3.0,
+            kappa_c=0.0,
+            kappa_p=0.0,
+        ),
+        fungus=FungusTraits(
+            initial_biomass=0.5,
+            initial_c_pool=0.5,
+            initial_p_pool=1.0,
+            gamma_c=1.0,
+            gamma_p=2.0,
+            kappa_c=0.0,
+            kappa_p=0.0,
+            saturation_density=3.0 / (2.0 * math.pi),
+            hyphal_tissue_carbon_density=1.0 / math.pi,
+            hyphal_radius=1.0,
+        ),
+    )
+    _, state = env.reset(jax.random.PRNGKey(0))
+
+    observations = env.get_obs(state)
+
+    expected = np.array([0.5, 0.5, 0.5, 0.0, 1.0], dtype=np.float32)
+    np.testing.assert_allclose(observations[PLANT], expected)
+    np.testing.assert_allclose(observations[FUNGUS], expected)
+
+
+def test_received_trade_is_reconstructed_from_state_against_maintenance_need():
+    env = _environment(
+        plant=PlantTraits(
+            initial_biomass=10.0,
+            initial_c_pool=20.0,
+            initial_p_pool=10.0,
+            biomass_cap=100.0,
+            kappa_p=0.2,
+        ),
+        fungus=FungusTraits(
+            initial_biomass=8.0,
+            initial_c_pool=12.0,
+            initial_p_pool=16.0,
+            kappa_c=0.5,
+        ),
+    )
+    _, state = env.reset(jax.random.PRNGKey(0))
+    saved_state = state.replace(
+        plant_last_p_received=jnp.array([2.0], dtype=jnp.float32),
+        fungus_last_c_received=jnp.array([4.0], dtype=jnp.float32),
+    )
+
+    observations = env.get_obs(saved_state)
+
+    assert observations[PLANT][3] == 0.5
+    assert observations[FUNGUS][3] == 0.5
+    leaves, tree = jax.tree_util.tree_flatten(saved_state)
+    restored_state = jax.tree_util.tree_unflatten(tree, leaves)
+    reconstructed = env.get_obs(restored_state)
+    np.testing.assert_array_equal(reconstructed[PLANT], observations[PLANT])
+    np.testing.assert_array_equal(reconstructed[FUNGUS], observations[FUNGUS])
+
+
+def test_step_stores_realised_received_trade_before_reconstructing_observations():
+    env = _environment()
+    _, state = env.reset(jax.random.PRNGKey(0))
+    trade_everything = {
+        PLANT: constrain_allocation(jnp.array([1.0, 0.0, 0.0, 0.0])),
+        FUNGUS: constrain_allocation(jnp.array([1.0, 0.0, 0.0, 0.0])),
+    }
+
+    observations, next_state, _, _, _ = env.step_env(
+        jax.random.PRNGKey(1), state, trade_everything
+    )
+
+    assert next_state.plant_last_p_received[0] == 16.0
+    assert next_state.fungus_last_c_received[0] == 20.0
+    reconstructed = env.get_obs(next_state)
+    np.testing.assert_array_equal(reconstructed[PLANT], observations[PLANT])
+    np.testing.assert_array_equal(reconstructed[FUNGUS], observations[FUNGUS])
+
+
+def test_actor_observation_contract_has_no_raw_observation_switch():
+    with pytest.raises(TypeError, match="norm_obs"):
+        EnvConfig(norm_obs=False)
+
+
+@pytest.mark.parametrize("pool_value", [0.0, 1e30])
+def test_zero_and_extreme_pools_produce_finite_bounded_observations(pool_value):
+    env = _environment()
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(
+        plant_c_pool=jnp.array([pool_value]),
+        plant_p_pool=jnp.array([pool_value]),
+        fungus_c_pool=jnp.array([pool_value]),
+        fungus_p_pool=jnp.array([pool_value]),
+    )
+
+    observations = env.get_obs(state)
+
+    for agent in (PLANT, FUNGUS):
+        assert jnp.all(jnp.isfinite(observations[agent]))
+        assert jnp.all((observations[agent] >= 0.0) & (observations[agent] <= 1.0))
+
+
+@pytest.mark.parametrize(
+    ("mode", "absent_agent", "present_agent"),
+    [
+        ("plant-only", FUNGUS, PLANT),
+        ("fungus-only", PLANT, FUNGUS),
+    ],
+)
+def test_single_consumer_modes_zero_absent_observation_and_association(
+    mode, absent_agent, present_agent
+):
+    config = EnvConfig(
+        dt=1.0,
+        max_steps=2,
+        consumer_mode=mode,
+        soil_radius_cm=1.0,
+        soil_depth_cm=1.0,
+        radial_interval_cm=0.5,
+        depth_interval_cm=0.5,
+        topsoil_depth_cm=0.5,
+        initial_solution_p_um=0.0,
+    )
+    env = _environment(config=config)
+
+    observations, _ = env.reset(jax.random.PRNGKey(0))
+
+    np.testing.assert_array_equal(
+        observations[absent_agent], np.zeros(5, dtype=np.float32)
+    )
+    assert observations[present_agent][4] == 0.0
+    assert jnp.any(observations[present_agent][:3] > 0.0)
+
+
+def test_partner_death_removes_association_and_dead_agent_observation():
+    env = _environment()
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(plant_dead=jnp.array([True]))
+
+    observations = env.get_obs(state)
+
+    np.testing.assert_array_equal(observations[PLANT], np.zeros(5, dtype=np.float32))
+    assert observations[FUNGUS][4] == 0.0
+    assert jnp.any(observations[FUNGUS][:3] > 0.0)
+
+
+def test_no_trade_transition_clears_previous_received_trade_memory():
+    env = _environment()
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(
+        plant_last_p_received=jnp.array([3.0]),
+        fungus_last_c_received=jnp.array([4.0]),
+    )
+    no_trade = {
+        PLANT: constrain_allocation(jnp.array([0.0, 1.0, 0.0, 0.0])),
+        FUNGUS: constrain_allocation(jnp.array([0.0, 1.0, 0.0, 0.0])),
+    }
+
+    observations, next_state, _, _, _ = env.step_env(
+        jax.random.PRNGKey(1), state, no_trade
+    )
+
+    assert next_state.plant_last_p_received[0] == 0.0
+    assert next_state.fungus_last_c_received[0] == 0.0
+    assert observations[PLANT][3] == 0.0
+    assert observations[FUNGUS][3] == 0.0
+
+
+def test_observations_reconstruct_under_jit_and_vectorised_environments():
+    env = _environment()
+    keys = jax.random.split(jax.random.PRNGKey(0), 2)
+
+    observations, states = jax.jit(jax.vmap(env.reset))(keys)
+    reconstructed = jax.jit(jax.vmap(env.get_obs))(states)
+
+    for agent in (PLANT, FUNGUS):
+        assert observations[agent].shape == (2, 5)
+        np.testing.assert_array_equal(reconstructed[agent], observations[agent])

--- a/tests/test_base_mycor_refactor.py
+++ b/tests/test_base_mycor_refactor.py
@@ -48,7 +48,6 @@ def config():
         depth_interval_cm=0.5,
         topsoil_depth_cm=0.5,
         initial_solution_p_um=0.0,
-        norm_obs=False,
     )
 
 
@@ -82,10 +81,10 @@ def test_reset_uses_zero_trade_observations(env):
     obs, state = env.reset(jax.random.PRNGKey(0))
 
     assert state.step == 0
-    assert obs[PLANT].shape == env.observation_spaces[PLANT].shape == (4,)
-    assert obs[FUNGUS].shape == env.observation_spaces[FUNGUS].shape == (4,)
-    assert obs[PLANT][-1] == 0.0
-    assert obs[FUNGUS][-1] == 0.0
+    assert obs[PLANT].shape == env.observation_spaces[PLANT].shape == (5,)
+    assert obs[FUNGUS].shape == env.observation_spaces[FUNGUS].shape == (5,)
+    assert obs[PLANT][3] == 0.0
+    assert obs[FUNGUS][3] == 0.0
 
 
 def test_step_trades_from_starting_pools_and_exposes_trade_in_obs(env):
@@ -102,8 +101,10 @@ def test_step_trades_from_starting_pools_and_exposes_trade_in_obs(env):
     assert next_state.plant_p_pool[0] == pytest.approx(26.0)
     assert next_state.fungus_c_pool[0] == pytest.approx(32.0)
     assert next_state.fungus_p_pool[0] == pytest.approx(0.0)
-    assert obs[PLANT][-1] == pytest.approx(16.0)
-    assert obs[FUNGUS][-1] == pytest.approx(20.0)
+    assert obs[PLANT][3] == pytest.approx(1.0)
+    assert obs[FUNGUS][3] == pytest.approx(1.0)
+    assert obs[PLANT][4] == pytest.approx(1.0)
+    assert obs[FUNGUS][4] == pytest.approx(1.0)
     assert rewards[PLANT] == pytest.approx(0.0)
     assert rewards[FUNGUS] == pytest.approx(0.0)
     assert dones["__all__"] == jnp.array(False)

--- a/tests/test_base_mycor_refactor.py
+++ b/tests/test_base_mycor_refactor.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from mycormarl.actions import physical_action
 from mycormarl.environments import base_mycor as env_mod
 from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
 from mycormarl.fungus.traits import FungusTraits
@@ -90,8 +91,8 @@ def test_reset_uses_zero_trade_observations(env):
 def test_step_trades_from_starting_pools_and_exposes_trade_in_obs(env):
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([1.0, 0.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([1.0, 0.0, 0.0, 0.0]),
+        PLANT: physical_action(1.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(1.0, 0.0, 0.0, 1.0),
     }
 
     obs, next_state, rewards, dones, infos = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -112,11 +113,30 @@ def test_step_trades_from_starting_pools_and_exposes_trade_in_obs(env):
     assert "growth" in infos[FUNGUS]
 
 
+def test_trade_is_independent_and_environment_executes_physical_action_unchanged(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    actions = {
+        PLANT: physical_action(0.5, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.5, 0.0, 0.0, 1.0),
+    }
+
+    _, next_state, _, _, infos = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    assert next_state.plant_c_pool[0] == pytest.approx(110.0)
+    assert next_state.plant_p_pool[0] == pytest.approx(18.0)
+    assert next_state.fungus_c_pool[0] == pytest.approx(22.0)
+    assert next_state.fungus_p_pool[0] == pytest.approx(8.0)
+    assert infos[PLANT]["proposed_trade_out"][0] == pytest.approx(10.0)
+    assert infos[FUNGUS]["proposed_trade_out"][0] == pytest.approx(8.0)
+
+
 def test_newly_fixed_carbon_is_not_available_for_same_step_growth(env):
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.0, 1.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, infos = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -137,8 +157,8 @@ def test_plant_growth_at_biomass_cap_charges_only_realised_structure(env):
         plant_p_pool=jnp.array([10.0]),
     )
     actions = {
-        PLANT: jnp.array([0.0, 1.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, infos = env.step_env(
@@ -152,6 +172,26 @@ def test_plant_growth_at_biomass_cap_charges_only_realised_structure(env):
         (next_state.plant_biomass[0] - state.plant_biomass[0])
         * env.species.plant.gamma_p
     )
+
+
+def test_essential_growth_returns_unused_non_limiting_allocation(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(plant_c_pool=jnp.array([20.0]), plant_p_pool=jnp.array([4.0]))
+    actions = {
+        PLANT: physical_action(0.0, 0.5, 0.0, 0.5),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
+    }
+
+    _, next_state, _, _, infos = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    assert infos[PLANT]["growth_c_allocated"][0] == pytest.approx(10.0)
+    assert infos[PLANT]["growth_p_allocated"][0] == pytest.approx(2.0)
+    assert infos[PLANT]["growth_c_used"][0] == pytest.approx(4.0)
+    assert infos[PLANT]["growth_p_used"][0] == pytest.approx(2.0)
+    assert next_state.plant_c_pool[0] == pytest.approx(136.0)
+    assert next_state.plant_p_pool[0] == pytest.approx(2.0)
 
 
 def test_dead_plant_cannot_resume_biology_while_fungus_remains_alive(env):
@@ -171,8 +211,8 @@ def test_dead_plant_cannot_resume_biology_while_fungus_remains_alive(env):
         )
     )
     maintenance_failure = {
-        PLANT: jnp.array([0.0, 0.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
     _, dead_state, _, dones, _ = env.step_env(
         jax.random.PRNGKey(1), state, maintenance_failure
@@ -188,8 +228,8 @@ def test_dead_plant_cannot_resume_biology_while_fungus_remains_alive(env):
         plant=env.species.plant.replace(kappa_c=0.0)
     )
     attempted_recovery = {
-        PLANT: jnp.array([1.0, 1.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(1.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
     biomass_before = dead_state.plant_biomass.copy()
     c_before = dead_state.plant_c_pool.copy()
@@ -210,8 +250,8 @@ def test_dead_plant_cannot_resume_biology_while_fungus_remains_alive(env):
 def test_incoming_trade_is_not_available_for_same_step_growth(env):
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.0, 1.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.5, 0.0, 0.5, 0.0]),
+        PLANT: physical_action(0.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.5, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, infos = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -220,12 +260,106 @@ def test_incoming_trade_is_not_available_for_same_step_growth(env):
     assert next_state.plant_p_pool[0] == pytest.approx(8.0)
 
 
+def test_plant_pays_automatic_maintenance_before_reserving_resources(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    env.species = env.species.replace(
+        plant=env.species.plant.replace(kappa_c=0.1, kappa_p=0.05)
+    )
+    actions = {
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
+    }
+
+    _, next_state, _, _, infos = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    assert infos[PLANT]["maint_c_used"][0] == pytest.approx(1.0)
+    assert infos[PLANT]["maint_p_used"][0] == pytest.approx(0.5)
+    assert next_state.plant_c_pool[0] == pytest.approx(119.0)
+    assert next_state.plant_p_pool[0] == pytest.approx(9.5)
+    assert next_state.cumulative_plant_p_maintenance_loss_mg[0] == pytest.approx(
+        0.5
+    )
+
+
+def test_maintenance_p_loss_records_only_the_amount_actually_paid(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(plant_p_pool=jnp.array([0.25]))
+    env.species = env.species.replace(
+        plant=env.species.plant.replace(kappa_c=0.0, kappa_p=0.05)
+    )
+    actions = {
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
+    }
+
+    _, next_state, _, _, infos = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    assert infos[PLANT]["maint_p"][0] == pytest.approx(0.5)
+    assert infos[PLANT]["maint_p_used"][0] == pytest.approx(0.25)
+    assert infos[PLANT]["p_deficit"][0] == pytest.approx(0.25)
+    assert next_state.cumulative_plant_p_maintenance_loss_mg[0] == pytest.approx(
+        0.25
+    )
+
+
+def test_fungus_pays_automatic_maintenance_before_reserving_resources(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    env.species = env.species.replace(
+        fungus=env.species.fungus.replace(kappa_c=0.25, kappa_p=0.125)
+    )
+    actions = {
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
+    }
+
+    _, next_state, _, _, infos = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    assert infos[FUNGUS]["maint_c_used"][0] == pytest.approx(2.0)
+    assert infos[FUNGUS]["maint_p_used"][0] == pytest.approx(1.0)
+    assert next_state.fungus_c_pool[0] == pytest.approx(10.0)
+    assert next_state.fungus_p_pool[0] == pytest.approx(15.0)
+    assert next_state.cumulative_fungus_p_maintenance_loss_mg[0] == pytest.approx(
+        1.0
+    )
+
+
+def test_maintenance_death_cancels_bilateral_trade_and_preserves_survivor_pool(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(plant_c_pool=jnp.array([0.0]))
+    env.species = env.species.replace(
+        plant=env.species.plant.replace(kappa_c=2.0, kappa_p=0.0)
+    )
+    actions = {
+        PLANT: physical_action(1.0, 0.0, 1.0, 0.0),
+        FUNGUS: physical_action(0.5, 0.0, 0.0, 1.0),
+    }
+
+    _, next_state, _, dones, infos = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    assert dones[PLANT]
+    assert not dones[FUNGUS]
+    assert infos[FUNGUS]["proposed_trade_out"][0] == pytest.approx(8.0)
+    assert infos[FUNGUS]["trade_out"][0] == pytest.approx(0.0)
+    assert infos[FUNGUS]["trade_cancelled"]
+    assert infos[PLANT]["reproduction_p"][0] == pytest.approx(0.0)
+    assert next_state.fungus_p_pool[0] == pytest.approx(16.0)
+    assert next_state.plant_p_pool[0] == pytest.approx(10.0)
+
+
 def test_reproduction_spends_pools_and_returns_reward(env):
     """Exports reproduced P and records it in the cumulative plant diagnostic."""
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 0.0, 1.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 1.0, 0.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, rewards, _, infos = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -247,8 +381,8 @@ def test_fungal_reproduction_export_is_accumulated(env):
         cumulative_fungus_p_reproduction_export_mg=jnp.array([2.0])
     )
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 1.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 0.0, 1.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 1.0, 0.0),
     }
 
     _, next_state, _, _, infos = env.step_env(
@@ -275,8 +409,8 @@ def test_reproduction_reward_uses_scaled_cobb_douglas(env):
     )
 
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 0.0, 1.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 1.0, 0.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, _, rewards, _, infos = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -286,7 +420,7 @@ def test_reproduction_reward_uses_scaled_cobb_douglas(env):
     assert rewards[PLANT] == pytest.approx(6.0)
 
 
-def test_excess_maintenance_allocation_is_not_wasted(env):
+def test_automatic_maintenance_does_not_spend_reserved_resources(env):
     _, state = env.reset(jax.random.PRNGKey(0))
     state = state.replace(
         plant_biomass=jnp.array([10.0]),
@@ -298,8 +432,8 @@ def test_excess_maintenance_allocation_is_not_wasted(env):
     )
 
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 1.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, infos = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -317,8 +451,8 @@ def test_excess_maintenance_allocation_is_not_wasted(env):
 def test_terminal_after_max_episode_steps(env):
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 1.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     for step in range(3):
@@ -326,3 +460,34 @@ def test_terminal_after_max_episode_steps(env):
 
     assert state.step == 3
     assert dones["__all__"] == jnp.array(True)
+
+
+def test_physical_resource_transaction_is_jittable_and_vectorised(env):
+    keys = jax.random.split(jax.random.PRNGKey(0), 2)
+    _, states = jax.vmap(env.reset)(keys)
+    actions = {
+        PLANT: jnp.stack(
+            [
+                physical_action(0.25, 0.5, 0.25, 0.25),
+                physical_action(0.75, 0.25, 0.5, 0.25),
+            ]
+        ),
+        FUNGUS: jnp.stack(
+            [
+                physical_action(0.5, 0.25, 0.25, 0.5),
+                physical_action(0.0, 0.5, 0.0, 0.5),
+            ]
+        ),
+    }
+    step = jax.jit(jax.vmap(env.step_env, in_axes=(0, 0, 0)))
+
+    _, next_states, _, _, _ = step(keys, states, actions)
+
+    for pool in (
+        next_states.plant_c_pool,
+        next_states.plant_p_pool,
+        next_states.fungus_c_pool,
+        next_states.fungus_p_pool,
+    ):
+        assert jnp.all(jnp.isfinite(pool))
+        assert jnp.all(pool >= 0.0)

--- a/tests/test_environment_phosphate_uptake.py
+++ b/tests/test_environment_phosphate_uptake.py
@@ -31,7 +31,6 @@ def _p3_config(initial_solution_p_um=1.0):
         initial_solution_p_um=initial_solution_p_um,
         theta_water=0.3,
         b_p=0.0,
-        norm_obs=False,
     )
 
 

--- a/tests/test_environment_phosphate_uptake.py
+++ b/tests/test_environment_phosphate_uptake.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from mycormarl.actions import physical_action
 from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
 from mycormarl.fungus.traits import FungusTraits
 from mycormarl.params import EnvConfig, SpeciesParams
@@ -243,8 +244,8 @@ def test_uptake_credit_cannot_fund_growth_in_the_same_step():
     env = BaseMycorMarl(_p3_config(), species)
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.0, 1.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, infos = env.step_env(
@@ -267,8 +268,8 @@ def test_end_to_end_uptake_conserves_soil_plus_free_pool_p():
         + state.fungus_p_pool[0]
     )
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 1.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, _ = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -325,8 +326,8 @@ def test_structural_p_removed_with_biomass_is_recorded_as_mortality_loss():
     env = BaseMycorMarl(_p3_config(initial_solution_p_um=0.0), species)
     _, state = env.reset(jax.random.PRNGKey(0))
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 1.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, _ = env.step_env(jax.random.PRNGKey(1), state, actions)

--- a/tests/test_growth_geometry.py
+++ b/tests/test_growth_geometry.py
@@ -8,6 +8,7 @@ from mycormarl.fungus.mycelium import (
     _volume_under_sphere_within_radius,
     axisymmetric_density_from_biomass,
     axisymmetric_hemisphere_cell_fractions,
+    fungal_biomass_for_colony_radius,
     hyphal_length_from_fungal_biomass,
 )
 from mycormarl.fungus.traits import FungusTraits
@@ -57,6 +58,20 @@ def test_one_gram_biomass_has_expected_root_and_hyphal_length():
 
     assert root_length == pytest.approx(15_769.266, rel=1e-6)
     assert hyphal_length == pytest.approx(5_511_859.501, rel=1e-6)
+
+
+def test_fungal_biomass_for_colony_radius_inverts_geometry_pipeline():
+    """A 2 cm radial fill maps through length and biomass in physical units."""
+    traits = FungusTraits(
+        gamma_c=0.5,
+        hyphal_tissue_carbon_density=4.0,
+        hyphal_radius=0.5,
+        saturation_density=3.0,
+    )
+
+    biomass_g = fungal_biomass_for_colony_radius(2.0, traits)
+
+    assert biomass_g == pytest.approx(315.8273408, rel=1e-6)
 
 
 def test_length_conversions_have_physical_zero_and_nonnegative_limits():
@@ -400,7 +415,6 @@ def _geometry_config():
         depth_interval_cm=1.0,
         topsoil_depth_cm=1.5,
         initial_solution_p_um=0.0,
-        norm_obs=False,
     )
 
 

--- a/tests/test_growth_geometry.py
+++ b/tests/test_growth_geometry.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from mycormarl.actions import physical_action
 from mycormarl.environments import base_mycor as env_mod
 from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
 from mycormarl.fungus.mycelium import (
@@ -458,8 +459,8 @@ def test_realised_growth_updates_geometry_before_soil_stage(monkeypatch):
 
     monkeypatch.setattr(env_mod, "evolve_soil_p", observe_geometry)
     actions = {
-        PLANT: jnp.array([0.0, 1.0, 0.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 1.0, 0.0, 0.0]),
+        PLANT: physical_action(0.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.0, 1.0, 0.0, 0.0),
     }
 
     _, next_state, _, _, _ = env.step_env(jax.random.PRNGKey(1), state, actions)
@@ -502,8 +503,8 @@ def test_maintenance_biomass_loss_contracts_geometry(monkeypatch):
 
     monkeypatch.setattr(env_mod, "evolve_soil_p", no_soil_uptake)
     actions = {
-        PLANT: jnp.array([0.0, 0.0, 1.0, 0.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(0.0, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, _, _, _ = env.step_env(jax.random.PRNGKey(1), state, actions)

--- a/tests/test_labile_phosphate_state.py
+++ b/tests/test_labile_phosphate_state.py
@@ -42,7 +42,6 @@ def small_config():
         initial_solution_p_um=2.0,
         theta_water=0.3,
         b_p=239.0,
-        norm_obs=False,
     )
 
 

--- a/tests/test_phosphate_diffusion.py
+++ b/tests/test_phosphate_diffusion.py
@@ -330,7 +330,6 @@ def _subcycling_config(dt_seconds=1.0):
         phosphate_diffusion_coefficient_cm2_s=1.0,
         phosphate_impedance_factor=1.0,
         diffusion_cfl_safety=0.8,
-        norm_obs=False,
     )
 
 

--- a/tests/test_phosphate_qualification.py
+++ b/tests/test_phosphate_qualification.py
@@ -49,7 +49,6 @@ def _diagnostic_environment():
         depth_interval_cm=1.0,
         topsoil_depth_cm=1.0,
         initial_solution_p_um=1.0,
-        norm_obs=False,
     )
     species = SpeciesParams(
         plant=PlantTraits(initial_biomass=0.0, initial_p_pool=0.0),

--- a/tests/test_review_repairs.py
+++ b/tests/test_review_repairs.py
@@ -29,7 +29,6 @@ def _small_config(mode="mixed"):
         depth_interval_cm=0.1,
         topsoil_depth_cm=0.2,
         consumer_mode=mode,
-        norm_obs=False,
     )
 
 

--- a/tests/test_review_repairs.py
+++ b/tests/test_review_repairs.py
@@ -9,6 +9,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from mycormarl.actions import physical_action
 from mycormarl.algos.ppo import make_train
 from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
 from mycormarl.fungus.traits import FungusTraits
@@ -74,8 +75,8 @@ def test_independent_consumer_mode_keeps_absent_partner_dormant(mode, inactive, 
     env = BaseMycorMarl(_small_config(mode), _species())
     _, state = env.reset(jax.random.PRNGKey(0))
     aggressive = {
-        PLANT: jnp.array([1.0, 1.0, 1.0, 1.0]),
-        FUNGUS: jnp.array([1.0, 1.0, 1.0, 1.0]),
+        PLANT: physical_action(1.0, 1.0, 1.0, 1.0),
+        FUNGUS: physical_action(1.0, 1.0, 1.0, 1.0),
     }
 
     for step in range(2):
@@ -101,8 +102,8 @@ def test_absorbing_death_removes_real_root_geometry_and_uptake():
     c_before = state.plant_c_pool.copy()
     p_before = state.plant_p_pool.copy()
     actions = {
-        PLANT: jnp.array([1.0, 1.0, 1.0, 1.0]),
-        FUNGUS: jnp.array([0.0, 0.0, 1.0, 0.0]),
+        PLANT: physical_action(1.0, 1.0, 1.0, 1.0),
+        FUNGUS: physical_action(0.0, 0.0, 0.0, 1.0),
     }
 
     _, next_state, rewards, dones, infos = env.step_env(

--- a/tests/test_review_repairs.py
+++ b/tests/test_review_repairs.py
@@ -142,6 +142,25 @@ def test_ppo_stack_accepts_current_agent_identifiers():
 
     assert set(output["runner_state"][0]) == {PLANT, FUNGUS}
     assert output["trajectories"][0].reward.shape[:2] == (1, 2)
+    final_state = output["runner_state"][1]
+    for pool in (
+        final_state.plant_c_pool,
+        final_state.plant_p_pool,
+        final_state.fungus_c_pool,
+        final_state.fungus_p_pool,
+    ):
+        assert jnp.all(jnp.isfinite(pool))
+        assert jnp.all(pool >= 0.0)
+    for trajectory in output["trajectories"]:
+        for field in (
+            "proposed_trade_out",
+            "growth_c_allocated",
+            "growth_p_allocated",
+            "reproduction_c",
+            "reproduction_p",
+        ):
+            assert jnp.all(jnp.isfinite(trajectory.info[field]))
+            assert jnp.all(trajectory.info[field] >= 0.0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,277 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+from mycormarl.actions import physical_action
+from mycormarl.environments.base_mycor import FUNGUS, PLANT, BaseMycorMarl
+from mycormarl.fungus.traits import FungusTraits
+from mycormarl.params import EnvConfig, SpeciesParams
+from mycormarl.plant.traits import PlantTraits
+from mycormarl.transition import Transition
+
+
+@pytest.fixture()
+def species():
+    return SpeciesParams(
+        plant=PlantTraits(
+            initial_biomass=10.0,
+            initial_c_pool=20.0,
+            initial_p_pool=10.0,
+            gamma_c=2.0,
+            gamma_p=1.0,
+            kappa_c=0.0,
+            kappa_p=0.0,
+            death_fraction=0.2,
+            biomass_cap=100.0,
+            kleaf=1.0,
+            amass=10.0,
+        ),
+        fungus=FungusTraits(
+            initial_biomass=8.0,
+            initial_c_pool=12.0,
+            initial_p_pool=16.0,
+            gamma_c=2.0,
+            gamma_p=1.0,
+            kappa_c=0.0,
+            kappa_p=0.0,
+            death_fraction=0.2,
+        ),
+    )
+
+
+@pytest.fixture()
+def config():
+    return EnvConfig(
+        dt=1.0,
+        soil_radius_cm=1.0,
+        radial_interval_cm=0.5,
+        soil_depth_cm=1.0,
+        depth_interval_cm=0.5,
+        topsoil_depth_cm=0.5,
+        initial_solution_p_um=0.0,
+    )
+
+
+@pytest.fixture()
+def env(species, config):
+    return BaseMycorMarl(config=config, species=species, max_episode_steps=3)
+
+
+def reserve_actions(*, plant_trade=0.0, fungus_trade=0.0):
+    return {
+        PLANT: physical_action(plant_trade, 0.0, 0.0, 1.0),
+        FUNGUS: physical_action(fungus_trade, 0.0, 0.0, 1.0),
+    }
+
+
+def test_ordinary_step_exposes_typed_transitions_separately_from_diagnostics(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    actions = reserve_actions(plant_trade=0.25, fungus_trade=0.5)
+
+    observations, _, _, _, info = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    transitions = info["transitions"]
+    assert set(transitions) == {PLANT, FUNGUS}
+    assert isinstance(transitions[PLANT], Transition)
+    assert isinstance(transitions[FUNGUS], Transition)
+    assert info[PLANT] is not transitions[PLANT]
+    assert info[FUNGUS] is not transitions[FUNGUS]
+
+    for agent in (PLANT, FUNGUS):
+        transition = transitions[agent]
+        assert transition.operational_at_start
+        assert transition.operational_at_end
+        assert transition.allocation_executed
+        assert transition.trade_executed
+        assert not transition.truncated
+        assert transition.requested_action == pytest.approx(actions[agent])
+        assert transition.realised_action == pytest.approx(actions[agent])
+        assert transition.final_observation == pytest.approx(observations[agent])
+
+
+@pytest.mark.parametrize(
+    ("consumer_mode", "operational_agent", "absent_agent"),
+    [
+        ("plant-only", PLANT, FUNGUS),
+        ("fungus-only", FUNGUS, PLANT),
+    ],
+)
+def test_single_consumer_step_preserves_fixed_transition_mapping(
+    species, config, consumer_mode, operational_agent, absent_agent
+):
+    env = BaseMycorMarl(
+        config=config.replace(consumer_mode=consumer_mode),
+        species=species,
+        max_episode_steps=3,
+    )
+    _, state = env.reset(jax.random.PRNGKey(0))
+    actions = reserve_actions(plant_trade=0.25, fungus_trade=0.5)
+
+    _, _, _, _, info = env.step_env(jax.random.PRNGKey(1), state, actions)
+
+    transitions = info["transitions"]
+    assert set(transitions) == {PLANT, FUNGUS}
+    assert transitions[operational_agent].operational_at_start
+    assert transitions[operational_agent].operational_at_end
+    assert transitions[operational_agent].allocation_executed
+    assert not transitions[operational_agent].trade_executed
+    assert not transitions[absent_agent].operational_at_start
+    assert not transitions[absent_agent].operational_at_end
+    assert not transitions[absent_agent].allocation_executed
+    assert not transitions[absent_agent].trade_executed
+    assert transitions[absent_agent].realised_action == pytest.approx(
+        jnp.zeros(4)
+    )
+
+
+def test_maintenance_death_differs_from_dead_padding_and_preserves_survivor_allocation(
+    env
+):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(
+        plant_biomass=jnp.array([1.0]),
+        plant_history_max_biomass=jnp.array([1.0]),
+        plant_c_pool=jnp.array([0.0]),
+        plant_p_pool=jnp.array([0.0]),
+    )
+    env.species = env.species.replace(
+        plant=env.species.plant.replace(
+            kappa_c=1.8,
+            death_fraction=0.2,
+        )
+    )
+    actions = {
+        PLANT: physical_action(1.0, 1.0, 0.0, 0.0),
+        FUNGUS: physical_action(0.5, 1.0, 0.0, 0.0),
+    }
+
+    _, dead_state, _, dones, info = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    death = info["transitions"]
+    assert dones[PLANT]
+    assert not dones["__all__"]
+    assert death[PLANT].operational_at_start
+    assert not death[PLANT].operational_at_end
+    assert not death[PLANT].allocation_executed
+    assert not death[PLANT].trade_executed
+    assert death[PLANT].realised_action == pytest.approx(jnp.zeros(4))
+    assert death[FUNGUS].operational_at_start
+    assert death[FUNGUS].operational_at_end
+    assert death[FUNGUS].allocation_executed
+    assert not death[FUNGUS].trade_executed
+    assert death[FUNGUS].realised_action == pytest.approx(
+        jnp.array([0.0, 1.0, 0.0, 0.0])
+    )
+
+    _, _, _, _, padding_info = env.step_env(
+        jax.random.PRNGKey(2), dead_state, actions
+    )
+    padding = padding_info["transitions"][PLANT]
+    survivor = padding_info["transitions"][FUNGUS]
+    assert not padding.operational_at_start
+    assert not padding.operational_at_end
+    assert not padding.allocation_executed
+    assert not padding.trade_executed
+    assert survivor.operational_at_start
+    assert survivor.operational_at_end
+    assert survivor.allocation_executed
+    assert not survivor.trade_executed
+
+
+def test_both_maintenance_deaths_are_biological_not_administrative(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    state = state.replace(
+        plant_biomass=jnp.array([1.0]),
+        fungus_biomass=jnp.array([1.0]),
+        plant_history_max_biomass=jnp.array([1.0]),
+        fungus_history_max_biomass=jnp.array([1.0]),
+        plant_c_pool=jnp.array([0.0]),
+        plant_p_pool=jnp.array([0.0]),
+        fungus_c_pool=jnp.array([0.0]),
+        fungus_p_pool=jnp.array([0.0]),
+    )
+    env.species = env.species.replace(
+        plant=env.species.plant.replace(kappa_c=1.8, death_fraction=0.2),
+        fungus=env.species.fungus.replace(kappa_c=1.8, death_fraction=0.2),
+    )
+
+    _, _, _, dones, info = env.step_env(
+        jax.random.PRNGKey(1), state, reserve_actions()
+    )
+
+    assert dones[PLANT]
+    assert dones[FUNGUS]
+    assert dones["__all__"]
+    for transition in info["transitions"].values():
+        assert transition.operational_at_start
+        assert not transition.operational_at_end
+        assert not transition.allocation_executed
+        assert not transition.trade_executed
+        assert not transition.truncated
+
+
+def test_auto_reset_returns_reset_observations_but_preserves_final_observations(
+    species, config
+):
+    env = BaseMycorMarl(config=config, species=species, max_episode_steps=1)
+    initial_observations, state = env.reset(jax.random.PRNGKey(0))
+    actions = reserve_actions(plant_trade=0.5, fungus_trade=0.5)
+    expected_final, _, _, _, _ = env.step_env(
+        jax.random.PRNGKey(1), state, actions
+    )
+
+    observations, reset_state, _, dones, info = env.step(
+        jax.random.PRNGKey(2), state, actions
+    )
+
+    assert dones["__all__"]
+    assert reset_state.step == 0
+    for agent in (PLANT, FUNGUS):
+        transition = info["transitions"][agent]
+        assert transition.truncated
+        assert observations[agent] == pytest.approx(initial_observations[agent])
+        assert transition.final_observation == pytest.approx(
+            expected_final[agent]
+        )
+        assert not jnp.allclose(
+            transition.final_observation,
+            observations[agent],
+        )
+    assert (
+        info["transitions"][PLANT].truncated
+        == info["transitions"][FUNGUS].truncated
+    )
+
+
+def test_transition_contract_is_stable_under_jit_and_vectorisation(env):
+    _, state = env.reset(jax.random.PRNGKey(0))
+    actions = reserve_actions(plant_trade=0.25, fungus_trade=0.5)
+
+    _, _, _, _, jitted_info = jax.jit(env.step_env)(
+        jax.random.PRNGKey(1), state, actions
+    )
+    assert isinstance(jitted_info["transitions"][PLANT], Transition)
+    assert jitted_info["transitions"][PLANT].requested_action.shape == (4,)
+    assert jitted_info["transitions"][PLANT].final_observation.shape == (5,)
+
+    keys = jax.random.split(jax.random.PRNGKey(2), 2)
+    states = jax.tree.map(lambda value: jnp.stack([value, value]), state)
+    batched_actions = jax.tree.map(
+        lambda value: jnp.stack([value, value]), actions
+    )
+    vectorised_step = jax.jit(jax.vmap(env.step_env, in_axes=(0, 0, 0)))
+
+    _, _, _, _, batched_info = vectorised_step(
+        keys, states, batched_actions
+    )
+
+    for transition in batched_info["transitions"].values():
+        assert isinstance(transition, Transition)
+        assert transition.operational_at_start.shape == (2,)
+        assert transition.requested_action.shape == (2, 4)
+        assert transition.final_observation.shape == (2, 5)
+        assert transition.truncated.shape == (2,)


### PR DESCRIPTION
Enforce stricter contracts and boundaries for observations and actions. 
Actions enforced as physical before entering BaseMycorMarl env, no manipulation is done in the environment. Actions now a trade plus simplex of (reproduction, growth, reserve).
Observations are normalised using saturating ratio bounds.
Transition objects defined for interpretation by PPO algorithm, the environment does not assume the algorithm is PPO, so decouples the two. PPO must know what transitions occurred inside the environment for decisions over whether such a learning step should be bootstrapped etc. – not if the agent is dead etc.